### PR TITLE
UnmarshalStrict: use DisallowUnknownFields

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -39,7 +39,7 @@ func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 // UnmarshalStrict strictly converts YAML to JSON then uses JSON to unmarshal
 // into an object, optionally configuring the behavior of the JSON unmarshal.
 func UnmarshalStrict(y []byte, o interface{}, opts ...JSONOpt) error {
-	return yamlUnmarshal(y, o, true, opts...)
+	return yamlUnmarshal(y, o, true, append(opts, DisallowUnknownFields)...)
 }
 
 // yamlUnmarshal unmarshals the given YAML byte stream into the given interface,

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -211,6 +211,15 @@ a:
 `)
 	s4 := NamedThing{}
 	unmarshalStrictFail(t, y, &s4)
+
+	// Strict unmarshal should fail for unknown fields
+	y = []byte(`
+name: TestB
+id: ID-B
+unknown: Some-Value
+`)
+	s5 := NamedThing{}
+	unmarshalStrictFail(t, y, &s5)
 }
 
 func unmarshalStrict(t *testing.T, y []byte, s, e interface{}, opts ...JSONOpt) {


### PR DESCRIPTION
Without this option the JSON decoder would tolerate
unknown fields.

looks like it was suggested earlier:
https://github.com/ghodss/yaml/pull/38#issuecomment-420416234

fixes #4 
/assign @dims 
/kind bug
cc @liztio 
