### PR TITLE
remove go 1.9.x from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 dist: xenial
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
 script:


### PR DESCRIPTION
1.9 is too old and does not support DisallowUnknownFields:
`./yaml.go:43:48: undefined: DisallowUnknownFields`

https://api.travis-ci.org/v3/job/450083074/log.txt

/kind bug
/assign @dims 
