### PR TITLE
CI: only test using 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: go
 dist: xenial
 go:
-  - 1.10.x
-  - 1.11.x
   - 1.12.x
 script:
   - diff -u <(echo -n) <(gofmt -d *.go)
   - diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)
-  - go vet .
-  - go test -v -race ./...
+  - GO111MODULE=on go vet .
+  - GO111MODULE=on go test -v -race ./...
 install:
   - go get golang.org/x/lint/golint


### PR DESCRIPTION
drop support for go1.11
k/k 's minimal version is at 1.12 and this repository now requires modules.

this is a setup for this PR:
https://github.com/kubernetes-sigs/yaml/pull/19

/kind cleanup
/assign @dims
