### PR TITLE
Fix go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ script:
   - diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)
   - GO111MODULE=on go vet .
   - GO111MODULE=on go test -v -race ./...
+  - git diff --exit-code
 install:
   - go get golang.org/x/lint/golint

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/kubernetes-sigs/yaml
+module sigs.k8s.io/yaml
 
 go 1.12
 
-require gopkg.in/yaml.v2 v2.2.2
+require (
+	github.com/davecgh/go-spew v1.1.1
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/yaml/issues/24

`github.com/davecgh/go-spew` is required by `yaml_test.go` which was added in https://github.com/kubernetes-sigs/yaml/pull/14.

This was not caught in tests because we just run a `go test`, which updates `go.mod` but we don't check if there were any new changes. This PR fixes it.


/cc @sttts @neolit123 @dims 