### PR TITLE
travis: add go 1.13 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 dist: xenial
 go:
   - 1.12.x
+  - 1.13.x
 script:
   - diff -u <(echo -n) <(gofmt -d *.go)
   - diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)


### PR DESCRIPTION
This makes sure that tests run against all currently supported Go versions