### PR TITLE
Fix json to yaml marshal results

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ func main() {
 	}
 	fmt.Println(string(y))
 	/* Output:
-	name: John
 	age: 30
+	name: John
 	*/
 	j2, err := yaml.YAMLToJSON(y)
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/yaml/issues/35

The original marshal result implies that the library will keep the sequence of json items while it actually doesn't. This PR is to avoid future confusion. 