### PR TITLE
Add CI tests for ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
-dist: xenial
-go:
-  - 1.12.x
-  - 1.13.x
+arch: arm64
+dist: focal
+go: 1.15.x
 script:
   - diff -u <(echo -n) <(gofmt -d *.go)
   - diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/yaml/issues/34#issuecomment-726326971

Skipping Go 1.14 because it was never used in any k8s release.
The `-race` flag is not supported on linux/arm.
Tests should fail until https://github.com/kubernetes-sigs/yaml/pull/42 is merged.