### PR TITLE
removed go v1.12.x and added go v1.15.x in github-actions ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix: 
-        go-versions: [1.12.x, 1.13.x, 1.14.x]
+        go-versions: [1.13.x, 1.14.x, 1.15.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR is in response to https://github.com/kubernetes-sigs/yaml/pull/50#discussion_r564588053