### PR TITLE
Replace go-spew with go-cmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module sigs.k8s.io/yaml
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.5.9
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -832,8 +832,8 @@ func TestJSONObjectToYAMLObject(t *testing.T) {
 			got := JSONObjectToYAMLObject(tt.input)
 			sortMapSlicesInPlace(tt.expected)
 			sortMapSlicesInPlace(got)
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("jsonToYAML() = %v, want %v", spew.Sdump(got), spew.Sdump(tt.expected))
+			if !reflect.DeepEqual(tt.expected, got) {
+				t.Errorf("jsonToYAML() returned unexpected results (-want+got):\n%v", cmp.Diff(tt.expected, got))
 			}
 
 			jsonBytes, err := json.Marshal(tt.input)
@@ -872,7 +872,8 @@ func TestJSONObjectToYAMLObject(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, gotByRoundtrip) {
-				t.Errorf("yaml.Unmarshal(json.Marshal(tt.input)) = %v, want %v\njson: %s", spew.Sdump(gotByRoundtrip), spew.Sdump(got), string(jsonBytes))
+				t.Errorf("yaml.Unmarshal(json.Marshal(tt.input)) returned unexpected results (-want+got):\n%v", cmp.Diff(got, gotByRoundtrip))
+				t.Errorf("json: %s", string(jsonBytes))
 			}
 		})
 	}


### PR DESCRIPTION
Produces more compact test failures messages.