### PR TITLE
RFC: remove github.com/google/go-cmp from main package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix: 
         go-versions: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        dir: ['.', 'test']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -21,11 +22,15 @@ jobs:
       run: GO111MODULE=off go get golang.org/x/lint/golint
     - name: Run gofmt
       run: diff -u <(echo -n) <(gofmt -d *.go)
+      working-directory: ${{ matrix.dir }}
     - name: Run golint
       run: diff -u <(echo -n) <(golint $(go list -e ./...) | grep -v YAMLToJSON)
+      working-directory: ${{ matrix.dir }}
     - name: Run go vet
       run: GO111MODULE=on go vet .
+      working-directory: ${{ matrix.dir }}
     - name: Run go test
       run: GO111MODULE=on go test -v -race ./...
+      working-directory: ${{ matrix.dir }}
     - name: Check diff
       run: git diff --exit-code

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module sigs.k8s.io/yaml
 
 go 1.12
 
-require (
-	github.com/google/go-cmp v0.5.9
-	gopkg.in/yaml.v2 v2.4.0
-)
+require gopkg.in/yaml.v2 v2.4.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,0 +1,11 @@
+module sigs.k8s.io/yaml/test
+
+go 1.12
+
+require (
+	github.com/google/go-cmp v0.5.9
+	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.3.0
+)
+
+replace sigs.k8s.io/yaml => ../

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/test/yaml_test.go
+++ b/test/yaml_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package yaml
+package test
 
 import (
 	"encoding/json"
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	yaml "gopkg.in/yaml.v2"
+	kyaml "sigs.k8s.io/yaml"
 )
 
 /* Test helper functions */
@@ -53,11 +54,11 @@ type testUnmarshalFunc = func(yamlBytes []byte, obj interface{}) error
 
 var (
 	funcUnmarshal testUnmarshalFunc = func(yamlBytes []byte, obj interface{}) error {
-		return Unmarshal(yamlBytes, obj)
+		return kyaml.Unmarshal(yamlBytes, obj)
 	}
 
 	funcUnmarshalStrict testUnmarshalFunc = func(yamlBytes []byte, obj interface{}) error {
-		return UnmarshalStrict(yamlBytes, obj)
+		return kyaml.UnmarshalStrict(yamlBytes, obj)
 	}
 )
 
@@ -114,11 +115,11 @@ type testYAMLToJSONFunc = func(yamlBytes []byte) ([]byte, error)
 
 var (
 	funcYAMLToJSON testYAMLToJSONFunc = func(yamlBytes []byte) ([]byte, error) {
-		return YAMLToJSON(yamlBytes)
+		return kyaml.YAMLToJSON(yamlBytes)
 	}
 
 	funcYAMLToJSONStrict testYAMLToJSONFunc = func(yamlBytes []byte) ([]byte, error) {
-		return YAMLToJSONStrict(yamlBytes)
+		return kyaml.YAMLToJSONStrict(yamlBytes)
 	}
 )
 
@@ -147,7 +148,7 @@ func testYAMLToJSON(t *testing.T, f testYAMLToJSONFunc, tests map[string]yamlToJ
 
 		t.Run(fmt.Sprintf("%s_JSONToYAML", testName), func(t *testing.T) {
 			// Convert JSON to YAML
-			yamlBytes, err := JSONToYAML([]byte(test.json))
+			yamlBytes, err := kyaml.JSONToYAML([]byte(test.json))
 			if err != nil {
 				t.Errorf("Failed to convert JSON to YAML, json: `%s`, err: %v", test.json, err)
 			}
@@ -183,7 +184,7 @@ func TestMarshal(t *testing.T) {
 	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat32}
 	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f32String))
 
-	y, err := Marshal(s)
+	y, err := kyaml.Marshal(s)
 	if err != nil {
 		t.Errorf("error marshaling YAML: %v", err)
 	}
@@ -829,7 +830,7 @@ func TestJSONObjectToYAMLObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := JSONObjectToYAMLObject(tt.input)
+			got := kyaml.JSONObjectToYAMLObject(tt.input)
 			sortMapSlicesInPlace(tt.expected)
 			sortMapSlicesInPlace(got)
 			if !reflect.DeepEqual(tt.expected, got) {


### PR DESCRIPTION
When moving the unit test into a sub-directory with its own go.mod file it becomes possible to remove the github.com/google/go-cmp dependency from the module gets imported by downstream consumers.