### PR TITLE
Switch to 'yaml.v3'

### DIFF
--- a/goyaml.v3/yaml.go
+++ b/goyaml.v3/yaml.go
@@ -17,8 +17,7 @@
 //
 // Source code and other details for the project are available at GitHub:
 //
-//   https://github.com/go-yaml/yaml
-//
+//	https://github.com/go-yaml/yaml
 package yaml
 
 import (
@@ -75,24 +74,24 @@ type Marshaler interface {
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     var t T
-//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	var t T
+//	yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
 func Unmarshal(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
 
 // A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	parser      *parser
-	knownFields bool
+	parser       *parser
+	knownFields  bool
+	noUniqueKeys bool
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -111,6 +110,11 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
+// UniqueKeys ensures that the keys in the yaml document are unique.
+func (dec *Decoder) UniqueKeys(enable bool) {
+	dec.noUniqueKeys = !enable
+}
+
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v.
 //
@@ -119,6 +123,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
+	d.uniqueKeys = !dec.noUniqueKeys
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -185,36 +190,35 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 //
 // The field tag format accepted is:
 //
-//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//	`(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Zero valued structs will be omitted if all their public
-//                  fields are zero, unless they implement an IsZero
-//                  method (see the IsZeroer interface type), in which
-//                  case the field will be excluded if IsZero returns true.
+//	omitempty    Only include the field if it's not set to the zero
+//	             value for the type or to empty slices or maps.
+//	             Zero valued structs will be omitted if all their public
+//	             fields are zero, unless they implement an IsZero
+//	             method (see the IsZeroer interface type), in which
+//	             case the field will be excluded if IsZero returns true.
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps).
+//	flow         Marshal using a flow style (useful for structs,
+//	             sequences and maps).
 //
-//     inline       Inline the field, which must be a struct or a map,
-//                  causing all of its fields or keys to be processed as if
-//                  they were part of the outer struct. For maps, keys must
-//                  not conflict with the yaml keys of other struct fields.
+//	inline       Inline the field, which must be a struct or a map,
+//	             causing all of its fields or keys to be processed as if
+//	             they were part of the outer struct. For maps, keys must
+//	             not conflict with the yaml keys of other struct fields.
 //
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-//
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
@@ -358,22 +362,21 @@ const (
 //
 // For example:
 //
-//     var person struct {
-//             Name    string
-//             Address yaml.Node
-//     }
-//     err := yaml.Unmarshal(data, &person)
-// 
+//	var person struct {
+//	        Name    string
+//	        Address yaml.Node
+//	}
+//	err := yaml.Unmarshal(data, &person)
+//
 // Or by itself:
 //
-//     var person Node
-//     err := yaml.Unmarshal(data, &person)
-//
+//	var person Node
+//	err := yaml.Unmarshal(data, &person)
 type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -420,7 +423,6 @@ func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
-
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -175,15 +175,13 @@ func testYAMLToJSON(t *testing.T, f testYAMLToJSONFunc, tests map[string]yamlToJ
 type MarshalTest struct {
 	A string
 	B int64
-	// Would like to test float64, but it's not supported in go-yaml.
-	// (See https://github.com/go-yaml/yaml/issues/83.)
-	C float32
+	C float64
 }
 
 func TestMarshal(t *testing.T) {
-	f32String := strconv.FormatFloat(math.MaxFloat32, 'g', -1, 32)
-	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat32}
-	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f32String))
+	f64String := strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)
+	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat64}
+	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f64String))
 
 	y, err := Marshal(s)
 	if err != nil {
@@ -296,12 +294,12 @@ func TestUnmarshal(t *testing.T) {
 		"tagged casematched boolean key (yes)": {
 			encoded:    []byte("Yes: test"),
 			decodeInto: new(UnmarshalTaggedStruct),
-			decoded:    UnmarshalTaggedStruct{TrueLower: "test"},
+			decoded:    UnmarshalTaggedStruct{YesUpper: "test"},
 		},
 		"tagged non-casematched boolean key (yes)": {
 			encoded:    []byte("yes: test"),
 			decodeInto: new(UnmarshalTaggedStruct),
-			decoded:    UnmarshalTaggedStruct{TrueLower: "test"},
+			decoded:    UnmarshalTaggedStruct{YesLower: "test"},
 		},
 		"tagged integer key": {
 			encoded:    []byte("3: test"),
@@ -343,7 +341,7 @@ func TestUnmarshal(t *testing.T) {
 		"boolean value (no) into string field": {
 			encoded:    []byte("a: no"),
 			decodeInto: new(UnmarshalStruct),
-			decoded:    UnmarshalStruct{A: "false"},
+			decoded:    UnmarshalStruct{A: "no"},
 		},
 
 		// decode into complex fields
@@ -390,7 +388,7 @@ func TestUnmarshal(t *testing.T) {
 			encoded:    []byte("Yes:"),
 			decodeInto: new(map[string]struct{}),
 			decoded: map[string]struct{}{
-				"true": {},
+				"Yes": {},
 			},
 		},
 		"string map: decode integer key": {
@@ -639,8 +637,8 @@ func TestYAMLToJSON(t *testing.T) {
 		},
 		"boolean value (no)": {
 			yaml:                 "t: no\n",
-			json:                 `{"t":false}`,
-			yamlReverseOverwrite: strPtr("t: false\n"),
+			json:                 `{"t":"no"}`,
+			yamlReverseOverwrite: strPtr("t: \"no\"\n"),
 		},
 		"integer value (2^53 + 1)": {
 			yaml:                 "t: 9007199254740993\n",
@@ -653,8 +651,9 @@ func TestYAMLToJSON(t *testing.T) {
 			yamlReverseOverwrite: strPtr("t: 1e+36\n"),
 		},
 		"line-wrapped string value": {
-			yaml: "t: this is very long line with spaces and it must be longer than 80 so we will repeat\n  that it must be longer that 80\n",
-			json: `{"t":"this is very long line with spaces and it must be longer than 80 so we will repeat that it must be longer that 80"}`,
+			yaml:                 "t: this is very long line with spaces and it must be longer than 80 so we will repeat\n  that it must be longer that 80\n",
+			json:                 `{"t":"this is very long line with spaces and it must be longer than 80 so we will repeat that it must be longer that 80"}`,
+			yamlReverseOverwrite: strPtr(`t: this is very long line with spaces and it must be longer than 80 so we will repeat that it must be longer that 80` + "\n"),
 		},
 		"empty yaml value": {
 			yaml:                 "t: ",
@@ -668,8 +667,8 @@ func TestYAMLToJSON(t *testing.T) {
 		},
 		"boolean key (no)": {
 			yaml:                 "no: a",
-			json:                 `{"false":"a"}`,
-			yamlReverseOverwrite: strPtr("\"false\": a\n"),
+			json:                 `{"no":"a"}`,
+			yamlReverseOverwrite: strPtr("\"no\": a\n"),
 		},
 		"integer key": {
 			yaml:                 "1: a",


### PR DESCRIPTION
Switches from the 'yaml.v2' fork to the 'yaml.v3' fork and removes workarounds that are no longer necessary.