### PR TITLE
fix: wrap errors returned by JSON unmarshal

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -92,7 +92,7 @@ func jsonUnmarshal(reader io.Reader, obj interface{}, opts ...JSONOpt) error {
 		d = opt(d)
 	}
 	if err := d.Decode(&obj); err != nil {
-		return fmt.Errorf("while decoding JSON: %v", err)
+		return fmt.Errorf("while decoding JSON: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently `%v` is used inside an `Errorf` call, this means the original errors is lost and cannot be unwrapped to. 

By changing it to `%w` the error is preserved and can be retrieved with `errors.As`.