### PR TITLE
yaml.v3: add FuzzEncodeFromJSON which signals roundtripping issues

### DIFF
--- a/goyaml.v3/fuzz_test.go
+++ b/goyaml.v3/fuzz_test.go
@@ -1,0 +1,74 @@
+//go:build go1.18
+// +build go1.18
+
+package yaml_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
+)
+
+// FuzzEncodeFromJSON checks that any JSON encoded value can also be encoded as YAML... and decoded.
+func FuzzEncodeFromJSON(f *testing.F) {
+	f.Add(`null`)
+	f.Add(`""`)
+	f.Add(`0`)
+	f.Add(`true`)
+	f.Add(`false`)
+	f.Add(`{}`)
+	f.Add(`[]`)
+	f.Add(`[[]]`)
+	f.Add(`{"a":[]}`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+
+		var v interface{}
+		if err := json.Unmarshal([]byte(s), &v); err != nil {
+			t.Skip("not valid JSON")
+		}
+
+		t.Logf("JSON %q", s)
+		t.Logf("Go   %q <%[1]x>", v)
+
+		// Encode as YAML
+		b, err := yaml.Marshal(v)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b)
+
+		// Decode as YAML
+		var v2 interface{}
+		if err := yaml.Unmarshal(b, &v2); err != nil {
+			t.Error(err)
+		}
+
+		t.Logf("Go   %q <%[1]x>", v2)
+
+		/*
+			// Handling of number is different, so we can't have universal exact matching
+			if !reflect.DeepEqual(v2, v) {
+				t.Errorf("mismatch:\n-      got: %#v\n- expected: %#v", v2, v)
+			}
+		*/
+
+		b2, err := yaml.Marshal(v2)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("YAML %q <%[1]x>", b2)
+
+		if !bytes.Equal(b, b2) {
+			t.Errorf("Marshal->Unmarshal->Marshal mismatch:\n- expected: %q\n- got:      %q", b, b2)
+		}
+
+	})
+}
+
+func TestEncodeString(t *testing.T) {
+	b, _ := yaml.Marshal(`\n`)
+	t.Logf("%q <%[1]x>", string(b))
+}

--- a/goyaml.v3/testdata/fuzz/FuzzEncodeFromJSON/c64b69bf2c432100
+++ b/goyaml.v3/testdata/fuzz/FuzzEncodeFromJSON/c64b69bf2c432100
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("-0")


### PR DESCRIPTION
[`gopkg.in/yaml.v3`](https://github.com/go-yaml/yaml) has roundtripping bugs that I have demonstrated using a fuzzer in go-yaml/yaml#1028. But that module looks unmaintained while it has a key position in the Go ecosystem. Cc: @niemeyer

I'm resubmitting this fuzzer here in hope it will get more attention here (well, hopefully not just from black hats).

```console
$ go test -fuzz F
OK: 50 passed
fuzz: elapsed: 0s, gathering baseline coverage: 0/9 completed
fuzz: elapsed: 0s, gathering baseline coverage: 9/9 completed, now fuzzing with 8 workers
fuzz: elapsed: 0s, execs: 8702 (34591/sec), new interesting: 45 (total: 54)
--- FAIL: FuzzEncodeFromJSON (0.26s)
    --- FAIL: FuzzEncodeFromJSON (0.00s)
        fuzz_test.go:33: JSON "-0"
        fuzz_test.go:34: Go   %!q(float64=-0) <-0x0p+00>
        fuzz_test.go:41: YAML "-0\n" <2d300a>
        fuzz_test.go:49: Go   '\x00' <0>
        fuzz_test.go:62: YAML "0\n" <300a>
        fuzz_test.go:65: Marshal->Unmarshal->Marshal mismatch:
            - expected: "-0\n"
            - got:      "0\n"
    
    Failing input written to testdata/fuzz/FuzzEncodeFromJSON/c64b69bf2c432100
    To re-run:
    go test -run=FuzzEncodeFromJSON/c64b69bf2c432100
FAIL
exit status 1
FAIL	sigs.k8s.io/yaml/goyaml.v3	4.082s
```