### PR TITLE
fix(encode): ensure quoting is maintained for scalars

### DIFF
--- a/goyaml.v3/encode.go
+++ b/goyaml.v3/encode.go
@@ -19,6 +19,7 @@ import (
 	"encoding"
 	"fmt"
 	"io"
+	"math/big"
 	"reflect"
 	"regexp"
 	"sort"
@@ -135,6 +136,9 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		return
 	case time.Duration:
 		e.stringv(tag, reflect.ValueOf(value.String()))
+		return
+	case *big.Int:
+		e.bigintv(tag, reflect.ValueOf(value.String()))
 		return
 	case Marshaler:
 		v, err := value.MarshalYAML()
@@ -380,6 +384,12 @@ func (e *encoder) intv(tag string, in reflect.Value) {
 func (e *encoder) uintv(tag string, in reflect.Value) {
 	s := strconv.FormatUint(in.Uint(), 10)
 	e.emitScalar(s, "", tag, yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
+}
+
+func (e *encoder) bigintv(tag string, in reflect.Value) {
+	value := &big.Int{}
+	s, _ := value.SetString(in.String(), 0)
+	e.emitScalar(s.String(), "", tag, yaml_PLAIN_SCALAR_STYLE, nil, nil, nil, nil)
 }
 
 func (e *encoder) timev(tag string, in reflect.Value) {

--- a/goyaml.v3/encode_test.go
+++ b/goyaml.v3/encode_test.go
@@ -27,7 +27,7 @@ import (
 	"os"
 
 	. "gopkg.in/check.v1"
-	"sigs.k8s.io/yaml/goyaml.v3"
+	yaml "sigs.k8s.io/yaml/goyaml.v3"
 )
 
 var marshalIntTest = 123
@@ -729,6 +729,40 @@ func (s *S) TestSortedOutput(c *C) {
 		}
 		last = index
 	}
+}
+
+func (s *S) TestQuotingMaintained(c *C) {
+	var buf bytes.Buffer
+	var yamlValue map[string]interface{}
+	const originalYaml = `data:
+    A1: "0x0000000000000000000000010000000000000000"
+    A2: "0x000000000000000000000000FFFFFFFFFFFFFFFF"
+    A3: "1234"
+    A4: 0x0000000000000000000000010000000000000000
+    A5: 0x000000000000000000000000FFFFFFFFFFFFFFFF
+    A6: 1234
+`
+	const outputYaml = `data:
+    A1: "0x0000000000000000000000010000000000000000"
+    A2: "0x000000000000000000000000FFFFFFFFFFFFFFFF"
+    A3: "1234"
+    A4: 18446744073709551616
+    A5: 18446744073709551615
+    A6: 1234
+`
+
+	dec := yaml.NewDecoder(strings.NewReader(originalYaml))
+	errDec := dec.Decode(&yamlValue)
+	c.Assert(errDec, IsNil)
+
+	enc := yaml.NewEncoder(&buf)
+	errEnc := enc.Encode(yamlValue)
+	c.Assert(errEnc, IsNil)
+
+	errClose := enc.Close()
+	c.Assert(errClose, IsNil)
+
+	c.Assert(buf.String(), Equals, outputYaml)
 }
 
 func newTime(t time.Time) *time.Time {

--- a/goyaml.v3/resolve.go
+++ b/goyaml.v3/resolve.go
@@ -17,7 +17,9 @@ package yaml
 
 import (
 	"encoding/base64"
+	"errors"
 	"math"
+	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
@@ -201,6 +203,17 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 			if err == nil {
 				return intTag, uintv
 			}
+
+			// If integer out of range, check if it's valid for bigger than 64 bytes
+			if errors.Is(err, strconv.ErrRange) {
+				value := &big.Int{}
+
+				result, ok := value.SetString(plain, 0)
+				if ok {
+					return intTag, result
+				}
+			}
+
 			if yamlStyleFloat.MatchString(plain) {
 				floatv, err := strconv.ParseFloat(plain, 64)
 				if err == nil {


### PR DESCRIPTION
Currently, when encoding or decoding integers bigger than 64 bytes using `sigs.k8s.io/yaml/goyaml.v3`, those values are interpreted as unequivocal strings, which causes quotes to be removed. However, those values should be treated as regular numbers since they conform to the integer format in the YAML specification and honour quoting when present in the original input.

Related to kubernetes-sigs/kustomize#5432 and kubernetes-sigs/kustomize#5558
Fixes #108