### PR TITLE
Test with Go 1.21 and later

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix: 
-        go-versions: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-versions: [1.21.x, 1.22.x, 1.23.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-versions }}
     - name: Install
-      run: GO111MODULE=off go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@latest
     - name: Run gofmt
       run: diff -u <(echo -n) <(gofmt -d *.go)
     - name: Run golint


### PR DESCRIPTION
Something ends up requiring the slices package, which was added in Go 1.21.

See https://github.com/kubernetes-sigs/yaml/actions/runs/11232030744/job/31222775425?pr=118 for example:

```
Run GO111MODULE=off go get golang.org/x/lint/golint
  GO111MODULE=off go get golang.org/x/lint/golint
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.16.15/x64
package slices: unrecognized import path "slices": import path does not begin with hostname
Error: Process completed with exit code 1.
```