### PR TITLE
fix: enforce int64 for large integer values in tests

### DIFF
--- a/goyaml.v2/decode_test.go
+++ b/goyaml.v2/decode_test.go
@@ -131,7 +131,7 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"bin": -42},
 	}, {
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
-		map[string]interface{}{"bin": -9223372036854775808},
+		map[string]interface{}{"bin": int64(-9223372036854775808)},
 	}, {
 		"decimal: +685_230",
 		map[string]int{"decimal": 685230},

--- a/goyaml.v3/decode_test.go
+++ b/goyaml.v3/decode_test.go
@@ -177,7 +177,7 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"bin": -42},
 	}, {
 		"bin: -0b1000000000000000000000000000000000000000000000000000000000000000",
-		map[string]interface{}{"bin": -9223372036854775808},
+		map[string]interface{}{"bin": int64(-9223372036854775808)},
 	}, {
 		"decimal: +685_230",
 		map[string]int{"decimal": 685230},

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -183,7 +183,7 @@ type MarshalTest struct {
 func TestMarshal(t *testing.T) {
 	f32String := strconv.FormatFloat(math.MaxFloat32, 'g', -1, 32)
 	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat32}
-	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f32String))
+	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", int64(math.MaxInt64), f32String))
 
 	y, err := Marshal(s)
 	if err != nil {
@@ -411,8 +411,8 @@ func TestUnmarshal(t *testing.T) {
 		// decoding integers
 		"decode 2^53 + 1 into int": {
 			encoded:    []byte("9007199254740993"),
-			decodeInto: new(int),
-			decoded:    9007199254740993,
+			decodeInto: new(int64),
+			decoded:    int64(9007199254740993),
 		},
 		"decode 2^53 + 1 into interface": {
 			encoded:    []byte("9007199254740993"),


### PR DESCRIPTION
The bug arises from the use of generic integer types `(int)` in test cases involving large numerical values that exceed the range of a `32-bit` integer.

In Go, the size of the int type depends on the platform, this behavior causes inconsistencies when handling large integers, such as `-9223372036854775808` and `9007199254740993`.

On 32-bit systems, these values cannot be represented correctly as int, leading to potential overflow or truncation errors. By explicitly using the `int64` type in the affected test cases, the code ensures proper handling and representation of large integers across all platforms, avoiding platform-specific bugs and improving the reliability of the tests.

## Reproduce

Run tests setting `GOARCH` to `386`.

```bash
GOARCH=386 GOOS=linux go test -vet=off -v -p 2 sigs.k8s.io/yaml sigs.k8s.io/yaml/goyaml.v2 sigs.k8s.io/yaml/goyaml.v3


# sigs.k8s.io/yaml/goyaml.v2_test [sigs.k8s.io/yaml/goyaml.v2.test]
goyaml.v2/decode_test.go:134:33: cannot use -9223372036854775808 (untyped int constant) as int value in map literal (overflows)
# sigs.k8s.io/yaml [sigs.k8s.io/yaml.test]
./yaml_test.go:186:50: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to fmt.Sprintf (overflows)
./yaml_test.go:415:16: cannot use 9007199254740993 (untyped int constant) as int value in struct literal (overflows)
FAIL	sigs.k8s.io/yaml [build failed]
FAIL	sigs.k8s.io/yaml/goyaml.v2 [build failed]
# sigs.k8s.io/yaml/goyaml.v3_test [sigs.k8s.io/yaml/goyaml.v3.test]
goyaml.v3/decode_test.go:180:33: cannot use -9223372036854775808 (untyped int constant) as int value in map literal (overflows)
FAIL	sigs.k8s.io/yaml/goyaml.v3 [build failed]
FAIL
```


## Changes

- Updated test cases in `goyaml.v2` and `goyaml.v3` `decode_test.go` to explicitly use `int64` for representing large integer values.
- Adjusted `yaml_test.go` to:
  - Use `int64` for `math.MaxInt64` in marshaling tests.
  - Decode integers greater than `2^53` into `int64` instead of `int` to ensure proper handling of large values.

These changes address potential issues with integer overflow and ensure compatibility across platforms with differing integer size representations.