### PR TITLE
Test against go 1.24.x

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix: 
-        go-versions: [1.21.x, 1.22.x, 1.23.x]
+        go-versions: [1.21.x, 1.22.x, 1.23.x, 1.24.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Things depending on this library are built with 1.24, so make sure it's also tested with it.