### PR TITLE
Use 'yaml.v3' (2nd try)

### DIFF
--- a/goyaml.v3/patch.go
+++ b/goyaml.v3/patch.go
@@ -37,3 +37,7 @@ func (e *Encoder) DefaultSeqIndent() {
 func yaml_emitter_process_line_comment(emitter *yaml_emitter_t) bool {
 	return yaml_emitter_process_line_comment_linebreak(emitter, false)
 }
+
+func (e *Encoder) SetWidth(width int) {
+	yaml_emitter_set_width(&e.encoder.emitter, width)
+}

--- a/goyaml.v3/patch_test.go
+++ b/goyaml.v3/patch_test.go
@@ -175,3 +175,17 @@ a:
 		t.Errorf("expected error, got none")
 	}
 }
+
+func (s *S) TestSetWidth(c *C) {
+	longString := "this is very long line with spaces and it must be longer than 80 so we will repeat that it must be longer that 80"
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	enc.SetWidth(80)
+	err := enc.Encode(map[string]interface{}{"a": longString})
+	c.Assert(err, Equals, nil)
+	err = enc.Close()
+	c.Assert(err, Equals, nil)
+	c.Assert(buf.String(), Equals, "a: this is very long line with spaces and it must be longer than 80 so we will repeat\n  that it must be longer that 80\n")
+}

--- a/goyaml.v3/yaml.go
+++ b/goyaml.v3/yaml.go
@@ -91,8 +91,9 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 
 // A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	parser      *parser
-	knownFields bool
+	parser       *parser
+	knownFields  bool
+	noUniqueKeys bool
 }
 
 // NewDecoder returns a new decoder that reads from r.
@@ -111,6 +112,11 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
+// UniqueKeys ensures that the keys in the yaml document are unique.
+func (dec *Decoder) UniqueKeys(enable bool) {
+	dec.noUniqueKeys = !enable
+}
+
 // Decode reads the next YAML-encoded value from its input
 // and stores it in the value pointed to by v.
 //
@@ -119,6 +125,7 @@ func (dec *Decoder) KnownFields(enable bool) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
+	d.uniqueKeys = !dec.noUniqueKeys
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {

--- a/yaml.go
+++ b/yaml.go
@@ -274,7 +274,7 @@ func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (in
 				// Stolen from go-yaml to use the same conversion to string as
 				// the go-yaml library uses to convert float to string when
 				// Marshaling.
-				s := strconv.FormatFloat(typedKey, 'g', -1, 32)
+				s := strconv.FormatFloat(typedKey, 'g', -1, 64)
 				switch s {
 				case "+Inf":
 					s = ".inf"
@@ -386,7 +386,7 @@ func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (in
 			case int64:
 				s = strconv.FormatInt(typedVal, 10)
 			case float64:
-				s = strconv.FormatFloat(typedVal, 'g', -1, 32)
+				s = strconv.FormatFloat(typedVal, 'g', -1, 64)
 			case uint64:
 				s = strconv.FormatUint(typedVal, 10)
 			case bool:

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -296,12 +296,12 @@ func TestUnmarshal(t *testing.T) {
 		"tagged casematched boolean key (yes)": {
 			encoded:    []byte("Yes: test"),
 			decodeInto: new(UnmarshalTaggedStruct),
-			decoded:    UnmarshalTaggedStruct{TrueLower: "test"},
+			decoded:    UnmarshalTaggedStruct{YesUpper: "test"}, // In yamlv2, this incorrectly set the TrueLower field instead
 		},
 		"tagged non-casematched boolean key (yes)": {
 			encoded:    []byte("yes: test"),
 			decodeInto: new(UnmarshalTaggedStruct),
-			decoded:    UnmarshalTaggedStruct{TrueLower: "test"},
+			decoded:    UnmarshalTaggedStruct{YesLower: "test"}, // In yamlv2, this incorrectly set the TrueLower field instead
 		},
 		"tagged integer key": {
 			encoded:    []byte("3: test"),
@@ -343,7 +343,7 @@ func TestUnmarshal(t *testing.T) {
 		"boolean value (no) into string field": {
 			encoded:    []byte("a: no"),
 			decodeInto: new(UnmarshalStruct),
-			decoded:    UnmarshalStruct{A: "false"},
+			decoded:    UnmarshalStruct{A: "no"}, // In yamlv2, this incorrectly set the value to "false"
 		},
 
 		// decode into complex fields
@@ -390,7 +390,7 @@ func TestUnmarshal(t *testing.T) {
 			encoded:    []byte("Yes:"),
 			decodeInto: new(map[string]struct{}),
 			decoded: map[string]struct{}{
-				"true": {},
+				"Yes": {}, // In yamlv2, this incorrectly set the key to "true"
 			},
 		},
 		"string map: decode integer key": {
@@ -639,8 +639,8 @@ func TestYAMLToJSON(t *testing.T) {
 		},
 		"boolean value (no)": {
 			yaml:                 "t: no\n",
-			json:                 `{"t":false}`,
-			yamlReverseOverwrite: strPtr("t: false\n"),
+			json:                 `{"t":"no"}`, // In yamlv2, this was interpreted as the boolean false
+			yamlReverseOverwrite: strPtr("t: \"no\"\n"),
 		},
 		"integer value (2^53 + 1)": {
 			yaml:                 "t: 9007199254740993\n",
@@ -668,8 +668,8 @@ func TestYAMLToJSON(t *testing.T) {
 		},
 		"boolean key (no)": {
 			yaml:                 "no: a",
-			json:                 `{"false":"a"}`,
-			yamlReverseOverwrite: strPtr("\"false\": a\n"),
+			json:                 `{"no":"a"}`, // In yamlv2, this was incorrectly converted to "false"
+			yamlReverseOverwrite: strPtr("\"no\": a\n"),
 		},
 		"integer key": {
 			yaml:                 "1: a",

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -175,15 +175,13 @@ func testYAMLToJSON(t *testing.T, f testYAMLToJSONFunc, tests map[string]yamlToJ
 type MarshalTest struct {
 	A string
 	B int64
-	// Would like to test float64, but it's not supported in go-yaml.
-	// (See https://github.com/go-yaml/yaml/issues/83.)
-	C float32
+	C float64
 }
 
 func TestMarshal(t *testing.T) {
-	f32String := strconv.FormatFloat(math.MaxFloat32, 'g', -1, 32)
-	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat32}
-	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f32String))
+	f64String := strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64)
+	s := MarshalTest{"a", math.MaxInt64, math.MaxFloat64}
+	e := []byte(fmt.Sprintf("A: a\nB: %d\nC: %s\n", math.MaxInt64, f64String))
 
 	y, err := Marshal(s)
 	if err != nil {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -211,6 +211,8 @@ type UnmarshalTaggedStruct struct {
 	IntBig2           string `json:"1000000000000000000000000000000000000"`
 	IntBig2Scientific string `json:"1e+36"`
 	Float3dot3        string `json:"3.3"`
+	FloatMax32        string `json:"3.4028234663852886e+38"`
+	FloatMax64        string `json:"1.7976931348623157e+308"`
 }
 
 type UnmarshalStruct struct {
@@ -320,6 +322,16 @@ func TestUnmarshal(t *testing.T) {
 			encoded:    []byte("3.3: test"),
 			decodeInto: new(UnmarshalTaggedStruct),
 			decoded:    UnmarshalTaggedStruct{Float3dot3: "test"},
+		},
+		"tagged max float32 key": {
+			encoded:    []byte("3.4028234663852886e+38: test"),
+			decodeInto: new(UnmarshalTaggedStruct),
+			decoded:    UnmarshalTaggedStruct{FloatMax32: "test"},
+		},
+		"tagged max float64 key": {
+			encoded:    []byte("1.7976931348623157e+308: test"),
+			decodeInto: new(UnmarshalTaggedStruct),
+			decoded:    UnmarshalTaggedStruct{FloatMax64: "test"},
 		},
 
 		// decode into string field
@@ -436,6 +448,38 @@ func TestUnmarshal(t *testing.T) {
 				"a": "",
 				"b": nil,
 			},
+		},
+
+		// decoding floats
+		"decode max float32 into float32": {
+			encoded:    []byte("3.4028234663852886e+38"),
+			decodeInto: new(float32),
+			decoded:    float32(math.MaxFloat32),
+		},
+		"decode max float32 into interface": {
+			encoded:    []byte("3.4028234663852886e+38"),
+			decodeInto: new(interface{}),
+			decoded:    float64(math.MaxFloat32),
+		},
+		"decode max float32 into string": {
+			encoded:    []byte("3.4028234663852886e+38"),
+			decodeInto: new(string),
+			decoded:    "3.4028234663852886e+38",
+		},
+		"decode max float64 into float64": {
+			encoded:    []byte("1.7976931348623157e+308"),
+			decodeInto: new(float64),
+			decoded:    math.MaxFloat64,
+		},
+		"decode max float64 into interface": {
+			encoded:    []byte("1.7976931348623157e+308"),
+			decodeInto: new(interface{}),
+			decoded:    math.MaxFloat64,
+		},
+		"decode max float64 into string": {
+			encoded:    []byte("1.7976931348623157e+308"),
+			decodeInto: new(string),
+			decoded:    "1.7976931348623157e+308",
 		},
 
 		// duplicate (non-casematched) keys (NOTE: this is very non-ideal behaviour!)


### PR DESCRIPTION
Continuation of https://github.com/kubernetes-sigs/yaml/pull/100

Switches from the 'yaml.v2' fork to the 'yaml.v3' fork. Tried to do this while maintaining backwards compatibility as much as possible.

Fixes some of the Yes = true and No = false confusion (see tests).