### PR TITLE
Add "kyaml" support and yamlfmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/go-cmp v0.5.9
 	go.yaml.in/yaml/v2 v2.4.2
 	go.yaml.in/yaml/v3 v3.0.3
+	sigs.k8s.io/randfill v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
 go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
+sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/kyaml/kyaml.go
+++ b/kyaml/kyaml.go
@@ -96,6 +96,7 @@ func (ky *Encoder) FromYAML(in io.Reader, out io.Writer) error {
 		if err := ky.renderDocument(&doc, 0, ky.flags(), out); err != nil {
 			return err
 		}
+		fmt.Fprintf(out, "\n")
 	}
 
 	return nil
@@ -112,7 +113,8 @@ func (ky *Encoder) FromObject(obj any, out io.Writer) error {
 	return ky.FromYAML(bytes.NewReader(jb), out)
 }
 
-// Marshal renders a single Go object as KYAML, without the header.
+// Marshal renders a single Go object as KYAML, without the header or trailing
+// newline.
 func (ky *Encoder) Marshal(obj any) ([]byte, error) {
 	// Convert the object to JSON bytes to take advantage of all the JSON tag
 	// handling and things like that.
@@ -210,7 +212,7 @@ func (ky *Encoder) renderNode(node *yaml.Node, indent int, flags flagMask, out i
 
 // renderDocument processes a YAML document node, rendering it to the output.
 // This function assumes that the output "cursor" is positioned at the start of
-// the document and should always emit a final newline.
+// the document. This does not emit a final newline.
 func (ky *Encoder) renderDocument(doc *yaml.Node, indent int, flags flagMask, out io.Writer) error {
 	if len(doc.Content) == 0 {
 		return fmt.Errorf("kyaml internal error: line %d: document has no content node (%d)", doc.Line, len(doc.Content))
@@ -243,18 +245,17 @@ func (ky *Encoder) renderDocument(doc *yaml.Node, indent int, flags flagMask, ou
 		if len(child.LineComment) > 0 {
 			ky.renderComments(" "+child.LineComment, 0, out)
 		}
-		fmt.Fprint(out, "\n")
 		if len(child.FootComment) > 0 {
-			ky.renderComments(child.FootComment, indent, out)
 			fmt.Fprint(out, "\n")
+			ky.renderComments(child.FootComment, indent, out)
 		}
 		if len(doc.LineComment) > 0 {
-			ky.renderComments(" "+doc.LineComment, 0, out)
 			fmt.Fprint(out, "\n")
+			ky.renderComments(" "+doc.LineComment, 0, out)
 		}
 		if len(doc.FootComment) > 0 {
-			ky.renderComments(doc.FootComment, indent, out)
 			fmt.Fprint(out, "\n")
+			ky.renderComments(doc.FootComment, indent, out)
 		}
 	}
 	return nil

--- a/kyaml/kyaml.go
+++ b/kyaml/kyaml.go
@@ -1,0 +1,734 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kyaml provides an encoder for KYAML, a strict subset of YAML that is
+// designed to be explicit and unambiguous.  KYAML is YAML, so any YAML parser
+// should be able to read it.
+//
+// KYAML is designed to be halfway between YAML and JSON, with the following
+// properties:
+//   - Not whitespace-sensitive
+//   - Allows comments
+//   - Allows trailing commas
+//   - Does not require quoted keys
+//
+// KYAML is an output format, and will follow these conventions:
+//   - Always double-quote strings, even if they are not ambiguous.
+//   - Only quote keys that might be ambiguously interpreted (e.g. "no" is
+//     always quoted).
+//   - Always use `{}` for structs and maps, and `[]` for lists.
+//   - Economize on vertical space by cuddling some kinds of brackets together.
+//   - Render multi-line strings with YAML's line folding, which is close to
+//     the Go string literal format.
+//
+// KYAML also includes a document-separator "header" (still valid YAML), which
+// helps to disambiguate a KYAML document from an ill-formed JSON document.
+//
+// Because KYAML is YAML, a KYAML multi-document is a YAML multi-document.
+package kyaml
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Encoder formats objects or YAML data (JSON is valid YAML) into KYAML. KYAML
+// is halfway between YAML and JSON, but is a strict subset of YAML, so it
+// should should be readable by any YAML parser. It is designed to be explicit
+// and unambiguous, and eschews significant whitespace.
+type Encoder struct{}
+
+// FromYAML renders a KYAML (multi-)document from YAML bytes (JSON is YAML),
+// including the KYAML header. The result always has a trailing newline.
+func (ky *Encoder) FromYAML(in io.Reader, out io.Writer) error {
+	// We need a YAML decoder to handle multi-document streams.
+	dec := yaml.NewDecoder(in)
+
+	// Process each document in the stream.
+	for {
+		var doc yaml.Node
+		err := dec.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error decoding: %v", err)
+		}
+		if doc.Kind != yaml.DocumentNode {
+			return fmt.Errorf("kyaml internal error: line %d: expected a document node, got %s", doc.Line, ky.nodeKindString(doc.Kind))
+		}
+
+		// Always emit a document separator, which helps disambiguate between YAML
+		// and JSON.
+		if _, err := fmt.Fprintln(out, "---"); err != nil {
+			return err
+		}
+
+		if err := ky.renderDocument(&doc, 0, flagsNone, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FromObject renders a KYAML document from a Go object, including the KYAML
+// header. The result always has a trailing newline.
+func (ky *Encoder) FromObject(obj any, out io.Writer) error {
+	jb, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("error marshaling to JSON: %v", err)
+	}
+	// JSON is YAML.
+	return ky.FromYAML(bytes.NewReader(jb), out)
+}
+
+// Marshal renders a single Go object as KYAML, without the header.
+func (ky *Encoder) Marshal(obj any) ([]byte, error) {
+	// Convert the object to JSON bytes to take advantage of all the JSON tag
+	// handling and things like that.
+	jb, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling to JSON: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	// JSON is YAML.
+	if err := ky.fromObjectYAML(bytes.NewReader(jb), buf); err != nil {
+		return nil, fmt.Errorf("error rendering object: %v", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (ky *Encoder) fromObjectYAML(in io.Reader, out io.Writer) error {
+	yb, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(yb, &doc); err != nil {
+		return fmt.Errorf("error decoding: %v", err)
+	}
+	if doc.Kind != yaml.DocumentNode {
+		return fmt.Errorf("kyaml internal error: line %d: expected document node, got %s", doc.Line, ky.nodeKindString(doc.Kind))
+	}
+
+	if err := ky.renderNode(&doc, 0, flagsNone, out); err != nil {
+		return fmt.Errorf("error rendering document: %v", err)
+	}
+
+	return nil
+}
+
+// From the YAML spec.
+const (
+	intTag       = "!!int"
+	floatTag     = "!!float"
+	boolTag      = "!!bool"
+	strTag       = "!!str"
+	timestampTag = "!!timestamp"
+	seqTag       = "!!seq"
+	mapTag       = "!!map"
+	nullTag      = "!!null"
+	binaryTag    = "!!binary"
+	mergeTag     = "!!merge"
+)
+
+type flagMask uint64
+
+const (
+	flagsNone     flagMask = 0
+	flagLazyQuote flagMask = 0x01
+	flagCompact   flagMask = 0x02
+)
+
+// renderDocument processes a YAML document node, rendering it to the output.
+// This function assumes that the output "cursor" is positioned at the start of
+// the document and should always emit a final newline.
+func (ky *Encoder) renderDocument(doc *yaml.Node, indent int, _ flagMask, out io.Writer) error {
+	if len(doc.Content) == 0 {
+		return fmt.Errorf("kyaml internal error: line %d: document has no content node (%d)", doc.Line, len(doc.Content))
+	}
+	if len(doc.Content) > 1 {
+		return fmt.Errorf("kyaml internal error: line %d: document has more than one content node (%d)", doc.Line, len(doc.Content))
+	}
+	if indent != 0 {
+		return fmt.Errorf("kyaml internal error: line %d: document non-zero indent (%d)", doc.Line, indent)
+	}
+
+	// For document nodes, the cursor is assumed to be ready to render.
+	if len(doc.HeadComment) > 0 {
+		ky.renderComments(doc.HeadComment, indent, out)
+		fmt.Fprint(out, "\n")
+	}
+	child := doc.Content[0]
+	if len(child.HeadComment) > 0 {
+		ky.renderComments(child.HeadComment, indent, out)
+		fmt.Fprint(out, "\n")
+	}
+	if err := ky.renderNode(child, indent, flagsNone, out); err != nil {
+		return err
+	}
+	if len(child.LineComment) > 0 {
+		ky.renderComments(" "+child.LineComment, 0, out)
+	}
+	fmt.Fprint(out, "\n")
+	if len(child.FootComment) > 0 {
+		ky.renderComments(child.FootComment, indent, out)
+		fmt.Fprint(out, "\n")
+	}
+	if len(doc.LineComment) > 0 {
+		ky.renderComments(" "+doc.LineComment, 0, out)
+		fmt.Fprint(out, "\n")
+	}
+	if len(doc.FootComment) > 0 {
+		ky.renderComments(doc.FootComment, indent, out)
+		fmt.Fprint(out, "\n")
+	}
+	return nil
+}
+
+// renderScalar processes a YAML scalar node, rendering it to the output.  This
+// DOES NOT render a trailing newline or head/line/foot comments, as those
+// require the parent context.
+func (ky *Encoder) renderScalar(node *yaml.Node, indent int, flags flagMask, out io.Writer) error {
+	switch node.Tag {
+	case intTag, floatTag, boolTag, nullTag:
+		fmt.Fprint(out, node.Value)
+	case strTag:
+		return ky.renderString(node.Value, indent+1, flags, out)
+	case timestampTag:
+		return ky.renderString(node.Value, indent+1, flagsNone, out)
+	default:
+		return fmt.Errorf("kyaml internal error: line %d: unknown tag %q on scalar node %q", node.Line, node.Tag, node.Value)
+	}
+	return nil
+}
+
+const kyamlFoldStr = "\\\n"
+
+// renderString processes a string (either single-line or multi-line),
+// rendering it to the output.  This DOES NOT render a trailing newline.
+func (ky *Encoder) renderString(val string, indent int, flags flagMask, out io.Writer) error {
+	lazyQuote := flags&flagLazyQuote != 0
+	compact := flags&flagCompact != 0
+
+	// If no newlines, just use standard Go quoting.
+	if compact || !strings.Contains(val, "\n") {
+		if lazyQuote && !needsQuotes(val) {
+			fmt.Fprint(out, val)
+		} else {
+			fmt.Fprint(out, strconv.Quote(val))
+		}
+		return nil
+	}
+
+	// The input has at least one newline. We will use YAML's line folding to
+	// make the output more readable.
+	//
+	// The rest of this is borrowed from Go's strconv.Quote implementation.
+
+	s := val
+
+	// accumulate into a buffer
+	buf := &bytes.Buffer{}
+
+	// opening quote and fold
+	fmt.Fprint(buf, `"`, kyamlFoldStr)
+
+	// Iterating a string with invalid UTF8 returns RuneError rather than the
+	// bytes, so we iterate the string and decode the runes. This is a bit
+	// slower, but gives us a better result.
+	for width := 0; len(s) > 0; s = s[width:] {
+		r := rune(s[0])
+		width = 1
+		if r >= utf8.RuneSelf {
+			r, width = utf8.DecodeRuneInString(s)
+		}
+		if width == 1 && r == utf8.RuneError {
+			fmt.Fprint(buf, `\x`)
+			fmt.Fprintf(buf, "%02x", s[0])
+			continue
+		}
+		ky.appendEscapedRune(r, indent, buf)
+	}
+
+	// closing quote
+	afterNewline := buf.Bytes()[len(buf.Bytes())-1] == '\n'
+	if !afterNewline {
+		fmt.Fprint(buf, kyamlFoldStr)
+	}
+	ky.writeIndent(indent, buf)
+	fmt.Fprint(buf, `"`)
+
+	fmt.Fprint(out, buf.String())
+
+	return nil
+}
+
+var allowedUnquotedAnywhere = map[rune]bool{
+	'_': true,
+}
+
+var allowedUnquotedInterior = map[rune]bool{
+	'-': true,
+	'.': true,
+	'/': true,
+}
+
+func needsQuotes(s string) bool {
+	if s == "" {
+		return true
+	}
+	if isTypeAmbiguous(s) {
+		return true
+	}
+	runes := []rune(s)
+	for i, r := range runes {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || allowedUnquotedAnywhere[r] {
+			continue
+		}
+		if i > 0 && i < len(runes)-1 && allowedUnquotedInterior[r] {
+			continue
+		}
+		// it's something we don't explicitly allow
+		return true
+	}
+	return false
+}
+
+// From https://yaml.org/type/int.html and https://yaml.org/type/float.html
+var sexagesimalRE = regexp.MustCompile(`^[+-]?[1-9][0-9_]*(:[0-5]?[0-9])+(\.[0-9_]*)?$`)
+
+// isTypeAmbiguous returns true if a YAML parser might interpret the unquoted
+// form of the string argument as a YAML type other than string (e.g. `true`
+// would be interpreted as a boolean).
+func isTypeAmbiguous(s string) bool {
+	// Null-like strings: https://yaml.org/type/null.html
+	if len(s) <= 5 {
+		switch strings.ToLower(s) {
+		case "null", "~", "":
+			return true
+		}
+	}
+
+	// Boolean-like strings: https://yaml.org/type/bool.html
+	if _, err := strconv.ParseBool(s); err == nil {
+		return true
+	}
+	if len(s) <= 5 {
+		switch strings.ToLower(s) {
+		case "true", "y", "yes", "on", "false", "n", "no", "off":
+			return true
+		}
+	}
+
+	// Number-like strings: https://yaml.org/type/int.html and
+	// https://yaml.org/type/float.html
+	//
+	// NOTE: the stripping of underscores is gross.
+	sWithoutUnderscores := strings.ReplaceAll(s, "_", "")
+	// Handles binary ("0b"), octal ("0" or "0o"), decimal, and hex ("0x")
+	if _, err := strconv.ParseInt(sWithoutUnderscores, 0, 64); err == nil && !isSyntaxError(err) {
+		return true
+	}
+	// Handles standard and scientific notation.
+	if _, err := strconv.ParseFloat(sWithoutUnderscores, 64); err == nil && !isSyntaxError(err) {
+		return true
+	}
+
+	// Sexagesimal strings like "11:00" (in YAML 1.1, removed in 1.2):
+	// https://yaml.org/type/int.html and https://yaml.org/type/float.html
+	if sexagesimalRE.MatchString(s) {
+		return true
+	}
+
+	// Infinity and NaN: https://yaml.org/type/float.html
+	if len(s) <= 5 {
+		switch strings.ToLower(s) {
+		case ".inf", "-.inf", "+.inf", ".nan":
+			return true
+		}
+	}
+
+	// Time-like strings
+	if _, matches := parseTimestamp(s); matches {
+		return true
+	}
+
+	return false
+}
+
+func isSyntaxError(err error) bool {
+	var numerr *strconv.NumError
+	if ok := errors.As(err, &numerr); ok {
+		return errors.Is(numerr.Err, strconv.ErrSyntax)
+	}
+	return false
+}
+
+// This is a subset of the formats allowed by the regular expression
+// defined at http://yaml.org/type/timestamp.html.
+//
+// NOTE: This was copied from go.yaml.in/yaml/v2
+var allowedTimestampFormats = []string{
+	"2006-1-2T15:4:5.999999999Z07:00", // RCF3339Nano with short date fields.
+	"2006-1-2t15:4:5.999999999Z07:00", // RFC3339Nano with short date fields and lower-case "t".
+	"2006-1-2 15:4:5.999999999",       // space separated with no time zone
+	"2006-1-2",                        // date only
+	// Notable exception: time.Parse cannot handle: "2001-12-14 21:59:43.10 -5"
+	// from the set of examples.
+}
+
+// parseTimestamp parses s as a timestamp string and
+// returns the timestamp and reports whether it succeeded.
+// Timestamp formats are defined at http://yaml.org/type/timestamp.html
+//
+// NOTE: This was copied from go.yaml.in/yaml/v2
+func parseTimestamp(s string) (time.Time, bool) {
+	// TODO write code to check all the formats supported by
+	// http://yaml.org/type/timestamp.html instead of using time.Parse.
+
+	// Quick check: all date formats start with YYYY-.
+	i := 0
+	for ; i < len(s); i++ {
+		if c := s[i]; c < '0' || c > '9' {
+			break
+		}
+	}
+	if i != 4 || i == len(s) || s[i] != '-' {
+		return time.Time{}, false
+	}
+	for _, format := range allowedTimestampFormats {
+		if t, err := time.Parse(format, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// We use a buffer here so we can peek backwards.
+func (ky *Encoder) appendEscapedRune(r rune, indent int, buf *bytes.Buffer) {
+	afterNewline := buf.Bytes()[len(buf.Bytes())-1] == '\n'
+
+	if afterNewline {
+		ky.writeIndent(indent, buf)
+		// We want to preserve leading whitespace in the source string, so if
+		// we find whitespace, we need to escape it.  We don't want to
+		// escape lines without leading whitespace, but we DO want to render
+		// the result with fidelity to vertical alignment, so we write an extra
+		// space.  This is OK, because all whitespace before the first
+		// non-whitespace character is dropped, as per YAML spec. If there are
+		// no lines with leading whitespace it looks like the indent is one too
+		// many, which seems OK.
+		if unicode.IsSpace(r) && r != '\n' {
+			buf.WriteRune('\\')
+		} else {
+			buf.WriteRune(' ')
+		}
+	}
+	if r == '"' || r == '\\' { // always escaped
+		buf.WriteRune('\\')
+		buf.WriteRune(r)
+		return
+	}
+	if unicode.IsPrint(r) {
+		buf.WriteRune(r)
+		return
+	}
+	switch r {
+	case '\a':
+		buf.WriteString(`\a`)
+	case '\b':
+		buf.WriteString(`\b`)
+	case '\f':
+		buf.WriteString(`\f`)
+	case '\n':
+		buf.WriteString(`\n`)
+		buf.WriteString(kyamlFoldStr)
+	case '\r':
+		buf.WriteString(`\r`)
+	case '\t':
+		buf.WriteString(`\t`)
+	case '\v':
+		buf.WriteString(`\v`)
+	default:
+		const hexits = "0123456789abcdef"
+		switch {
+		case r < ' ' || r == 0x7f:
+			buf.WriteString(`\x`)
+			buf.WriteByte(hexits[byte(r)>>4])
+			buf.WriteByte(hexits[byte(r)&0xF])
+		case !utf8.ValidRune(r):
+			r = utf8.RuneError
+			fallthrough
+		case r < 0x10000:
+			buf.WriteString(`\u`)
+			for s := 12; s >= 0; s -= 4 {
+				buf.WriteByte(hexits[r>>uint(s)&0xF])
+			}
+		default:
+			buf.WriteString(`\U`)
+			for s := 28; s >= 0; s -= 4 {
+				buf.WriteByte(hexits[r>>uint(s)&0xF])
+			}
+		}
+	}
+}
+
+// renderSequence processes a YAML sequence node, rendering it to the output.  This
+// DOES NOT render a trailing newline or head/line/foot comments of the sequence
+// itself, but DOES render comments of the child nodes.
+func (ky *Encoder) renderSequence(node *yaml.Node, indent int, _ flagMask, out io.Writer) error {
+	if len(node.Content) == 0 {
+		fmt.Fprint(out, "[]")
+		return nil
+	}
+
+	// See if this list can use cuddled formatting.
+	cuddle := true
+	for _, child := range node.Content {
+		if !isCuddledKind(child) {
+			cuddle = false
+			break
+		}
+		if len(child.HeadComment)+len(child.LineComment)+len(child.FootComment) > 0 {
+			cuddle = false
+			break
+		}
+	}
+
+	if cuddle {
+		return ky.renderCuddledSequence(node, indent, out)
+	}
+	return ky.renderUncuddledSequence(node, indent, out)
+}
+
+// renderCuddledSequence processes a YAML sequence node which has already been
+// determined to be cuddled.  We only cuddle sequences of structs or lists
+// which have no comments.
+func (ky *Encoder) renderCuddledSequence(node *yaml.Node, indent int, out io.Writer) error {
+	fmt.Fprint(out, "[")
+	for i, child := range node.Content {
+		// Each iteration should leave us cuddled for the next item.
+		if i > 0 {
+			fmt.Fprint(out, ", ")
+		}
+		if err := ky.renderNode(child, indent, flagsNone, out); err != nil {
+			return err
+		}
+	}
+	fmt.Fprint(out, "]")
+
+	return nil
+}
+
+func (ky *Encoder) renderUncuddledSequence(node *yaml.Node, indent int, out io.Writer) error {
+	// Get into the right state for the first item.
+	fmt.Fprint(out, "[\n")
+	ky.writeIndent(indent, out)
+	for _, child := range node.Content {
+		// Each iteration should leave us ready to close the list. Since we
+		// have an item to render, we need 1 more indent.
+		ky.writeIndent(1, out)
+
+		if len(child.HeadComment) > 0 {
+			ky.renderComments(child.HeadComment, indent+1, out)
+			fmt.Fprint(out, "\n")
+			ky.writeIndent(indent+1, out)
+		}
+
+		if err := ky.renderNode(child, indent+1, flagsNone, out); err != nil {
+			return err
+		}
+
+		fmt.Fprint(out, ",")
+		if len(child.LineComment) > 0 {
+			ky.renderComments(" "+child.LineComment, 0, out)
+		}
+		fmt.Fprint(out, "\n")
+		ky.writeIndent(indent, out)
+		if len(child.FootComment) > 0 {
+			ky.writeIndent(1, out)
+			ky.renderComments(child.FootComment, indent+1, out)
+			fmt.Fprint(out, "\n")
+			ky.writeIndent(indent, out)
+		}
+	}
+	fmt.Fprint(out, "]")
+
+	return nil
+}
+
+func (ky *Encoder) nodeKindString(kind yaml.Kind) string {
+	switch kind {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return "unknown"
+	}
+}
+
+func isCuddledKind(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case yaml.SequenceNode, yaml.MappingNode:
+		return true
+	case yaml.AliasNode:
+		return isCuddledKind(node.Alias)
+	}
+	return false
+}
+
+// renderMapping processes a YAML mapping node, rendering it to the output.  This
+// DOES NOT render a trailing newline or head/line/foot comments of the mapping
+// itself, but DOES render comments of the child nodes.
+func (ky *Encoder) renderMapping(node *yaml.Node, indent int, _ flagMask, out io.Writer) error {
+	if len(node.Content) == 0 {
+		fmt.Fprint(out, "{}")
+		return nil
+	}
+
+	joinComments := func(a, b string) string {
+		if len(a) > 0 && len(b) > 0 {
+			return a + "\n" + b
+		}
+		return a + b
+	}
+
+	fmt.Fprint(out, "{\n")
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := node.Content[i+1]
+
+		ky.writeIndent(indent+1, out)
+
+		// Only one of these should be set.
+		if comments := joinComments(key.HeadComment, val.HeadComment); len(comments) > 0 {
+			ky.renderComments(comments, indent+1, out)
+			fmt.Fprint(out, "\n")
+			ky.writeIndent(indent+1, out)
+		}
+
+		// Mapping keys are always strings in KYAML, even if the YAML node says
+		// otherwise.
+		if err := ky.renderString(key.Value, indent+1, flagLazyQuote|flagCompact, out); err != nil {
+			return err
+		}
+		fmt.Fprint(out, ": ")
+		if err := ky.renderNode(val, indent+1, flagsNone, out); err != nil {
+			return err
+		}
+		fmt.Fprint(out, ",")
+		if len(key.LineComment) > 0 && len(val.LineComment) > 0 {
+			return fmt.Errorf("kyaml internal error: line %d: both key and value have line comments", key.Line)
+		}
+		if len(key.LineComment) > 0 {
+			ky.renderComments(" "+key.LineComment, 0, out)
+		} else if len(val.LineComment) > 0 {
+			ky.renderComments(" "+val.LineComment, 0, out)
+		}
+		fmt.Fprint(out, "\n")
+		// Only one of these should be set.
+		if comments := joinComments(key.FootComment, val.FootComment); len(comments) > 0 {
+			ky.writeIndent(indent+1, out)
+			ky.renderComments(comments, indent+1, out)
+			fmt.Fprint(out, "\n")
+		}
+	}
+	ky.writeIndent(indent, out)
+	fmt.Fprint(out, "}")
+	return nil
+}
+
+func (ky *Encoder) writeIndent(level int, out io.Writer) {
+	const indentString = "  "
+	for range level {
+		fmt.Fprint(out, indentString)
+	}
+}
+
+// renderCommentBlock writes the comments node to the output.  This assumes the
+// cursor is at the right place to start writing and DOES NOT render a trailing
+// newline.
+func (ky *Encoder) renderComments(comments string, indent int, out io.Writer) {
+	if len(comments) == 0 {
+		return
+	}
+	lines := strings.Split(comments, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			fmt.Fprint(out, "\n")
+			ky.writeIndent(indent, out)
+		}
+		fmt.Fprint(out, line)
+	}
+}
+
+func (ky *Encoder) renderAlias(node *yaml.Node, indent int, flags flagMask, out io.Writer) error {
+	if node.Alias != nil {
+		return ky.renderNode(node.Alias, indent+1, flags, out)
+	}
+	return nil
+}
+
+// renderNode processes a YAML node, calling the appropriate render function
+// for its type.  Each render function should assume that the output "cursor"
+// is positioned at the start of the node and should not emit a final newline.
+// If a render function needs to linewrap or indent (e.g. a struct), it should
+// assume the indent level is currently correct for the node type itself, and
+// may need to indent more.
+func (ky *Encoder) renderNode(node *yaml.Node, indent int, flags flagMask, out io.Writer) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		return ky.renderDocument(node, indent, flags, out)
+	case yaml.ScalarNode:
+		return ky.renderScalar(node, indent, flags, out)
+	case yaml.SequenceNode:
+		return ky.renderSequence(node, indent, flags, out)
+	case yaml.MappingNode:
+		return ky.renderMapping(node, indent, flags, out)
+	case yaml.AliasNode:
+		return ky.renderAlias(node, indent, flags, out)
+	}
+	return nil
+}

--- a/kyaml/kyaml.go
+++ b/kyaml/kyaml.go
@@ -207,7 +207,7 @@ func (ky *Encoder) renderNode(node *yaml.Node, indent int, flags flagMask, out i
 	case yaml.AliasNode:
 		return ky.renderAlias(node, indent, flags, out)
 	}
-	return nil
+	return fmt.Errorf("kyaml internal error: line %d: unknown node kind %v", node.Line, node.Kind)
 }
 
 // renderDocument processes a YAML document node, rendering it to the output.

--- a/kyaml/kyaml_omitzero_test.go
+++ b/kyaml/kyaml_omitzero_test.go
@@ -1,0 +1,68 @@
+//go:build go1.24
+// +build go1.24
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kyaml
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestKYAMLOutputSyntax_omitzero(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    any
+		expected string
+	}
+
+	tests := []testCase{
+		{"omitzero struct", struct {
+			I int    `json:",omitzero"`
+			S string `json:",omitzero"`
+			B bool   `json:",omitzero"`
+			P *int   `json:",omitzero"`
+		}{}, "{}"},
+		{"omitzero struct nil slice", struct {
+			S []int `json:",omitzero"`
+		}{}, "{}"},
+		{"omitzero struct zero slice", struct {
+			S []int `json:",omitzero"`
+		}{S: []int{}}, "{\n  S: [],\n}"},
+		{"omitzero struct nil map", struct {
+			M map[int]int `json:",omitzero"`
+		}{}, "{}"},
+		{"omitzero struct zero map", struct {
+			M map[int]int `json:",omitzero"`
+		}{M: map[int]int{}}, "{\n  M: {},\n}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ky := &Encoder{}
+			yb, err := ky.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("failed to render KYAML: %v", err)
+			}
+			// always has a newline at the end
+			if result := strings.TrimRight(string(yb), "\n"); result != tt.expected {
+				t.Errorf("Marshal(%v):\nwanted: %q\n   got: %q", tt.input, tt.expected, result)
+			}
+		})
+	}
+}

--- a/kyaml/kyaml_test.go
+++ b/kyaml/kyaml_test.go
@@ -1970,3 +1970,98 @@ func TestIsTypeAmbiguous(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderStringEscapes(t *testing.T) {
+	simpleCases := []struct {
+		name   string
+		input  rune
+		expect string
+	}{{
+		name:   "backslash",
+		input:  '\\',
+		expect: `"\\"`,
+	}, {
+		name:   "dquote",
+		input:  '"',
+		expect: `"\""`,
+	}, {
+		name:   "bell",
+		input:  '\a',
+		expect: `"\a"`,
+	}, {
+		name:   "backspace",
+		input:  '\b',
+		expect: `"\b"`,
+	}, {
+		name:   "ff",
+		input:  '\f',
+		expect: `"\f"`,
+	}, {
+		name:   "nl",
+		input:  '\n',
+		expect: "\"\\\n \\n\\\n\"",
+	}, {
+		name:   "cr",
+		input:  '\r',
+		expect: `"\r"`,
+	}, {
+		name:   "tab",
+		input:  '\t',
+		expect: `"\t"`,
+	}, {
+		name:   "vtab",
+		input:  '\v',
+		expect: `"\v"`,
+	}, {
+		name:   "null",
+		input:  '\x00',
+		expect: `"\0"`,
+	}, {
+		name:   "esc",
+		input:  '\x1b',
+		expect: `"\e"`,
+	}, {
+		name:   "nextline",
+		input:  '\u0085',
+		expect: `"\N"`,
+	}, {
+		name:   "nbsp",
+		input:  '\u00a0',
+		expect: `"\_"`,
+	}, {
+		name:   "linesep",
+		input:  '\u2028',
+		expect: `"\L"`,
+	}, {
+		name:   "parasep",
+		input:  '\u2029',
+		expect: `"\P"`,
+	}, {
+		name:   "x01",
+		input:  '\x01',
+		expect: `"\x01"`,
+	}, {
+		name:   "uffff",
+		input:  '\uffff',
+		expect: `"\uffff"`,
+	}, {
+		name:   "U0010ffff",
+		input:  '\U0010ffff',
+		expect: `"\U0010ffff"`,
+	}}
+
+	for _, tt := range simpleCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ky := &Encoder{}
+			buf := &bytes.Buffer{}
+			err := ky.renderString(string(tt.input), 0, 0, buf)
+			if err != nil {
+				t.Fatalf("renderString(%q) returned error: %v", tt.input, err)
+			}
+			if result := buf.String(); result != tt.expect {
+				t.Errorf("renderString(%q): want %q, got %q", tt.input, tt.expect, result)
+			}
+		})
+	}
+
+}

--- a/kyaml/kyaml_test.go
+++ b/kyaml/kyaml_test.go
@@ -1870,10 +1870,14 @@ func TestKYAMLFromYAML(t *testing.T) {
 				simple: |
 				  This is a multi-line string.
 				  It has multiple lines.
-				leading_space: |
+				leading_spaces: |
 				  This is a multi-line string.
 				    It can
-				      retain indentation.
+				      retain space indentation.
+				leading_tabs: |
+				  This is a multi-line string.
+				  	It can
+				  		retain tab indentation.
 				blank_lines: |
 				  This is a multi-line string.
 
@@ -1886,10 +1890,15 @@ func TestKYAMLFromYAML(t *testing.T) {
 				     This is a multi-line string.\n\
 				     It has multiple lines.\n\
 				    ",
-				  leading_space: "\
+				  leading_spaces: "\
 				     This is a multi-line string.\n\
 				    \  It can\n\
-				    \    retain indentation.\n\
+				    \    retain space indentation.\n\
+				    ",
+				  leading_tabs: "\
+				     This is a multi-line string.\n\
+				    \	It can\n\
+				    \		retain tab indentation.\n\
 				    ",
 				  blank_lines: "\
 				     This is a multi-line string.\n\
@@ -1904,7 +1913,8 @@ func TestKYAMLFromYAML(t *testing.T) {
 			name: "multi-line strings dquoted",
 			input: `
 				simple: "This is a multi-line string.\nIt has multiple lines.\n"
-				eading_space: "This is a multi-line string.\n  It can\n    retain indentation.\n"
+				leading_spaces: "This is a multi-line string.\n  It can\n    retain space indentation.\n"
+				leading_tabs: "This is a multi-line string.\n\tIt can\n\t\tretain tab indentation.\n"
 				blank_lines: "This is a multi-line string.\n\nIt can retain blank lines.\n"
 				`,
 			expected: `
@@ -1914,10 +1924,15 @@ func TestKYAMLFromYAML(t *testing.T) {
 				     This is a multi-line string.\n\
 				     It has multiple lines.\n\
 				    ",
-				  leading_space: "\
+				  leading_spaces: "\
 				     This is a multi-line string.\n\
 				    \  It can\n\
-				    \    retain indentation.\n\
+				    \    retain space indentation.\n\
+				    ",
+				  leading_tabs: "\
+				     This is a multi-line string.\n\
+				    \	It can\n\
+				    \		retain tab indentation.\n\
 				    ",
 				  blank_lines: "\
 				     This is a multi-line string.\n\
@@ -2419,7 +2434,7 @@ func TestRenderStringEscapes(t *testing.T) {
 	}, {
 		name:   "tab",
 		input:  '\t',
-		expect: `"\t"`,
+		expect: "\"\t\"",
 	}, {
 		name:   "vtab",
 		input:  '\v',

--- a/kyaml/kyaml_test.go
+++ b/kyaml/kyaml_test.go
@@ -1380,54 +1380,61 @@ func TestKYAMLOutput(t *testing.T) {
 // KYAML.
 func TestKYAMLFromYAML(t *testing.T) {
 	type testCase struct {
-		name     string
-		input    string
-		expected string
+		name          string
+		input         string
+		expectRegular string
+		expectCompact string
 	}
 
 	tests := []testCase{
 		{ // Without comments
-			name:     "empty YAML",
-			input:    ``,
-			expected: ``,
+			name:          "empty YAML",
+			input:         ``,
+			expectRegular: ``,
+			expectCompact: ``,
 		}, {
 			name:  "int",
 			input: `42`,
-			expected: `
+			expectRegular: `
 				---
 				42
 				`,
+			expectCompact: "---\n42\n",
 		}, {
 			name:  "bool",
 			input: `true`,
-			expected: `
+			expectRegular: `
 				---
 				true
 				`,
+			expectCompact: "---\ntrue\n",
 		}, {
 			name:  "naked string",
 			input: `a string`,
-			expected: `
+			expectRegular: `
 				---
 				"a string"
 				`,
+			expectCompact: "---\n\"a string\"\n",
 		}, {
 			name:  "quoted string",
 			input: `a string`,
-			expected: `
+			expectRegular: `
 				---
 				"a string"
 				`,
+			expectCompact: "---\n\"a string\"\n",
 		}, {
 			name: "empty list",
 			input: `
 				[
 				]
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[]
 				`,
+			expectCompact: "---\n[]\n",
 		}, {
 			name: "list of int",
 			input: `
@@ -1436,7 +1443,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				- 2
 				- 3
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[
 				  1,
@@ -1444,6 +1451,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  3,
 				]
 				`,
+			expectCompact: "---\n[1, 2, 3]\n",
 		}, {
 			name: "list of bool",
 			input: `
@@ -1452,7 +1460,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				- false
 				- true
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[
 				  true,
@@ -1460,6 +1468,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  true,
 				]
 				`,
+			expectCompact: "---\n[true, false, true]\n",
 		}, {
 			name: "list of string",
 			input: `
@@ -1468,7 +1477,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				- "dquoted"
 				- 'squoted'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[
 				  "naked",
@@ -1476,16 +1485,18 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "squoted",
 				]
 				`,
+			expectCompact: "---\n[\"naked\", \"dquoted\", \"squoted\"]\n",
 		}, {
 			name: "empty mapping",
 			input: `
 				{
 				}
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{}
 				`,
+			expectCompact: "---\n{}\n",
 		}, {
 			name: "mapping of ints",
 			input: `
@@ -1493,7 +1504,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				b: 2
 				c: 3
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  a: 1,
@@ -1501,6 +1512,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  c: 3,
 				}
 				`,
+			expectCompact: "---\n{a: 1, b: 2, c: 3}\n",
 		}, {
 			name: "mapping of bool",
 			input: `
@@ -1508,7 +1520,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				b: false
 				c: true
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  a: true,
@@ -1516,6 +1528,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  c: true,
 				}
 				`,
+			expectCompact: "---\n{a: true, b: false, c: true}\n",
 		}, {
 			name: "mapping of string",
 			input: `
@@ -1523,7 +1536,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				b: "dquoted"
 				c: 'squoted'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  a: "naked",
@@ -1531,6 +1544,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  c: "squoted",
 				}
 				`,
+			expectCompact: "---\n{a: \"naked\", b: \"dquoted\", c: \"squoted\"}\n",
 		}, {
 			// Note: there's no escaping within single-quotes.
 			name: "mapping of strings with quotes",
@@ -1539,7 +1553,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				b: "dquoted \"with\" 'quotes' embedded"
 				c: 'squoted "with" quotes embedded'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  a: "naked \"with\" 'quotes' embedded",
@@ -1547,6 +1561,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  c: "squoted \"with\" quotes embedded",
 				}
 				`,
+			expectCompact: "---\n{a: \"naked \\\"with\\\" 'quotes' embedded\", b: \"dquoted \\\"with\\\" 'quotes' embedded\", c: \"squoted \\\"with\\\" quotes embedded\"}\n",
 		}, {
 			name: "list of list",
 			input: `
@@ -1563,7 +1578,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  - "dquoted"
 				  - 'squoted'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[[
 				  1,
@@ -1579,6 +1594,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "squoted",
 				]]
 				`,
+			expectCompact: "---\n[[1, 2, 3], [true, false, true], [\"naked\", \"dquoted\", \"squoted\"]]\n",
 		}, {
 			name: "list of mapping",
 			input: `
@@ -1592,7 +1608,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  b: "dquoted"
 				  c: 'squoted'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[{
 				  a: 1,
@@ -1608,6 +1624,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  c: "squoted",
 				}]
 				`,
+			expectCompact: "---\n[{a: 1, b: 2, c: 3}, {a: true, b: false, c: true}, {a: \"naked\", b: \"dquoted\", c: \"squoted\"}]\n",
 		}, {
 			name: "mapping of list",
 			input: `
@@ -1624,7 +1641,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				- "dquoted"
 				- 'squoted'
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  a: [
@@ -1644,6 +1661,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  ],
 				}
 				`,
+			expectCompact: "---\n{a: [1, 2, 3], b: [true, false, true], c: [\"naked\", \"dquoted\", \"squoted\"]}\n",
 		}, {
 			name: "mapping with null-string keys",
 			input: `
@@ -1652,7 +1670,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				NULL: 123
 				~: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "null": 123,
@@ -1661,6 +1679,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "~": 123,
 				}
 				`,
+			expectCompact: "---\n{\"null\": 123, \"Null\": 123, \"NULL\": 123, \"~\": 123}\n",
 		}, {
 			name: "mapping with true-string keys",
 			input: `
@@ -1674,7 +1693,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				Yes: 123
 				YES: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "true": 123,
@@ -1688,6 +1707,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "YES": 123,
 				}
 				`,
+			expectCompact: "---\n{\"true\": 123, \"True\": 123, \"TRUE\": 123, \"on\": 123, \"On\": 123, \"ON\": 123, \"yes\": 123, \"Yes\": 123, \"YES\": 123}\n",
 		}, {
 			name: "mapping with false-string keys",
 			input: `
@@ -1701,7 +1721,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				No: 123
 				NO: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "false": 123,
@@ -1715,6 +1735,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "NO": 123,
 				}
 				`,
+			expectCompact: "---\n{\"false\": 123, \"False\": 123, \"FALSE\": 123, \"off\": 123, \"Off\": 123, \"OFF\": 123, \"no\": 123, \"No\": 123, \"NO\": 123}\n",
 		}, {
 			name: "mapping with int-string keys",
 			input: `
@@ -1728,7 +1749,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				_-_1__2__: 123
 				_+_1__2__: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "1": 123,
@@ -1742,6 +1763,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "_+_1__2__": 123,
 				}
 				`,
+			expectCompact: "---\n{\"1\": 123, \"-1\": 123, \"+1\": 123, \"_1\": 123, \"-_1\": 123, \"+_1\": 123, \"__1__2__\": 123, \"_-_1__2__\": 123, \"_+_1__2__\": 123}\n",
 		}, {
 			name: "mapping with float-string keys",
 			input: `
@@ -1753,7 +1775,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				+.inf: 123
 				.nan: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "3.14": 123,
@@ -1765,6 +1787,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  ".nan": 123,
 				}
 				`,
+			expectCompact: "---\n{\"3.14\": 123, \"-3.14\": 123, \"+3.14\": 123, \".inf\": 123, \"-.inf\": 123, \"+.inf\": 123, \".nan\": 123}\n",
 		}, {
 			name: "mapping with naked-string keys",
 			input: `
@@ -1775,7 +1798,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				with.dot: 123
 				with/slash: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  safe: 123,
@@ -1786,19 +1809,21 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  with/slash: 123,
 				}
 				`,
+			expectCompact: "---\n{safe: 123, _: 123, _with_underscore_: 123, with-dash: 123, with.dot: 123, with/slash: 123}\n",
 		}, {
 			name: "mapping with unsafe-string keys",
 			input: `
 				not safe: 123
 				with\backslash: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "not safe": 123,
 				  "with\\backslash": 123,
 				}
 				`,
+			expectCompact: "---\n{\"not safe\": 123, \"with\\\\backslash\": 123}\n",
 		}, {
 			name: "mapping with dash-string keys",
 			input: `
@@ -1806,7 +1831,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				-leading-dash: 123
 				trailing-dash-: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "-": 123,
@@ -1814,6 +1839,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "trailing-dash-": 123,
 				}
 				`,
+			expectCompact: "---\n{\"-\": 123, \"-leading-dash\": 123, \"trailing-dash-\": 123}\n",
 		}, {
 			name: "mapping with dot-string keys",
 			input: `
@@ -1821,7 +1847,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				.leading.dot: 123
 				trailing.dot.: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  ".": 123,
@@ -1829,6 +1855,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "trailing.dot.": 123,
 				}
 				`,
+			expectCompact: "---\n{\".\": 123, \".leading.dot\": 123, \"trailing.dot.\": 123}\n",
 		}, {
 			name: "mapping with slash-string keys",
 			input: `
@@ -1836,7 +1863,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				/leading/slash: 123
 				trailing/slash/: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "/": 123,
@@ -1844,6 +1871,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "trailing/slash/": 123,
 				}
 				`,
+			expectCompact: "---\n{\"/\": 123, \"/leading/slash\": 123, \"trailing/slash/\": 123}\n",
 		}, {
 			name: "mapping with date-string keys",
 			input: `
@@ -1852,7 +1880,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				2006-1-2T15:4:5.999999999-08:00: 123
 				11:00: 123
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  "2006": 123,
@@ -1861,6 +1889,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  "11:00": 123,
 				}
 				`,
+			expectCompact: "---\n{\"2006\": 123, \"2006-1-2\": 123, \"2006-1-2T15:4:5.999999999-08:00\": 123, \"11:00\": 123}\n",
 		}, {
 			// This case covers: multi-line, with and without leading spaces
 			// and blank lines.  It's hard to see whitespace, so subsequent
@@ -1883,7 +1912,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 
 				  It can retain blank lines.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  simple: "\
@@ -1907,6 +1936,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				    ",
 				}
 				`,
+			expectCompact: "---\n{simple: \"This is a multi-line string.\\nIt has multiple lines.\\n\", leading_spaces: \"This is a multi-line string.\\n  It can\\n    retain space indentation.\\n\", leading_tabs: \"This is a multi-line string.\\n\\tIt can\\n\\t\\tretain tab indentation.\\n\", blank_lines: \"This is a multi-line string.\\n\\nIt can retain blank lines.\\n\"}\n",
 		}, {
 			// This case covers: multi-line, with and without leading spaces
 			// and blank lines.
@@ -1917,7 +1947,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				leading_tabs: "This is a multi-line string.\n\tIt can\n\t\tretain tab indentation.\n"
 				blank_lines: "This is a multi-line string.\n\nIt can retain blank lines.\n"
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  simple: "\
@@ -1941,6 +1971,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				    ",
 				}
 				`,
+			expectCompact: "---\n{simple: \"This is a multi-line string.\\nIt has multiple lines.\\n\", leading_spaces: \"This is a multi-line string.\\n  It can\\n    retain space indentation.\\n\", leading_tabs: \"This is a multi-line string.\\n\\tIt can\\n\\t\\tretain tab indentation.\\n\", blank_lines: \"This is a multi-line string.\\n\\nIt can retain blank lines.\\n\"}\n",
 		},
 		{ // With comments
 			name: "scalar with comments",
@@ -1951,7 +1982,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -1959,6 +1990,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n42\n",
 		}, {
 			name: "multi-line string with comments",
 			input: `
@@ -1971,7 +2003,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  # This is a head comment.
@@ -1985,6 +2017,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  # It can also be multi-line.
 				}
 				`,
+			expectCompact: "---\n{foo: \"this is a\\nmulti-line\\ncomment\\n\"}\n",
 		}, {
 			name: "block sequence with comments",
 			input: `
@@ -1996,7 +2029,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[
 				  # This seems like a head comment.
@@ -2008,6 +2041,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  # It can also be multi-line.
 				]
 				`,
+			expectCompact: "---\n[1, 2, 3]\n",
 		}, {
 			name: "short flow sequence with line-comment",
 			input: `
@@ -2017,7 +2051,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2029,6 +2063,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n[1, 2, 3]\n",
 		}, {
 			name: "flow sequence with comments",
 			input: `
@@ -2042,7 +2077,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2054,6 +2089,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n[1, 2, 3]\n",
 		}, {}, {
 			name: "block mapping with comments",
 			input: `
@@ -2064,7 +2100,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				{
 				  # This is a head comment.
@@ -2075,6 +2111,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  # It can also be multi-line.
 				}
 				`,
+			expectCompact: "---\n{foo: 1, bar: 2}\n",
 		}, {
 			name: "short flow mapping with line-comment",
 			input: `
@@ -2084,7 +2121,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2095,6 +2132,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n{foo: 1, bar: 2}\n",
 		}, {
 			name: "flow mapping with comments",
 			input: `
@@ -2107,7 +2145,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2118,6 +2156,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n{foo: 1, bar: 2}\n",
 		}, {
 			name: "list of list with comments",
 			input: `
@@ -2141,7 +2180,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2181,6 +2220,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n[[1], [2], [3], [4], [5], [6], [7], [8], [9]]\n",
 		}, {
 			name: "list of map with comments",
 			input: `
@@ -2204,7 +2244,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This is a head comment.
 				# It can be multi-line.
@@ -2244,6 +2284,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n[{fld: 1}, {fld: 2}, {fld: 3}, {fld: 4}, {fld: 5}, {fld: 6}, {fld: 7}, {fld: 8}, {fld: 9}]\n",
 		}, {
 			name: "list of mixed types",
 			input: `
@@ -2255,7 +2296,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  [a, b, c],
 				]
 				`,
-			expected: `
+			expectRegular: `
 				---
 				[
 				  "a string",
@@ -2271,6 +2312,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				  ],
 				]
 				`,
+			expectCompact: "---\n[\"a string\", 12345, true, {fld: 1}, [\"a\", \"b\", \"c\"]]\n",
 		}, {
 			name: "doc comments",
 			input: `
@@ -2282,7 +2324,7 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
-			expected: `
+			expectRegular: `
 				---
 				# This seems like a doc comment.
 				# But it will be attributed to the content.
@@ -2291,23 +2333,35 @@ func TestKYAMLFromYAML(t *testing.T) {
 				# This is a foot comment.
 				# It can also be multi-line.
 				`,
+			expectCompact: "---\n42\n",
 		},
+	}
+
+	test := func(t *testing.T, ky *Encoder, input string, expect string) {
+		t.Helper()
+
+		input = dedent(strings.TrimLeft(input, "\n"))
+		expect = dedent(strings.TrimPrefix(expect, "\n"))
+
+		buf := bytes.Buffer{}
+		if err := ky.FromYAML(strings.NewReader(input), &buf); err != nil {
+			t.Fatalf("failed to render KYAML from YAML: %v", err)
+		}
+		if want, got := expect, buf.String(); got != want {
+			t.Errorf("FromYAML() got wrong result:\nwanted:\n```\n%s\n```\ngot:\n```\n%s\n```\n\nor:\n\nwanted: %q\n   got: %q\n", want, got, want, got)
+		}
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ky := &Encoder{}
-
-			input := dedent(strings.TrimLeft(tt.input, "\n"))
-			expected := dedent(strings.TrimPrefix(tt.expected, "\n"))
-
-			buf := &bytes.Buffer{}
-			if err := ky.FromYAML(strings.NewReader(input), buf); err != nil {
-				t.Fatalf("FromYAML(%q) returned error: %v", input, err)
-			}
-			if want, got := expected, buf.String(); got != want {
-				t.Errorf("FromYAML:\nexpected:\n```\n%s\n```\ngot:\n```\n%s\n```\n\nor:\n\nexpected: %q\n     got: %q\n", expected, got, expected, got)
-			}
+			t.Run("regular", func(t *testing.T) {
+				ky := &Encoder{}
+				test(t, ky, tt.input, tt.expectRegular)
+			})
+			t.Run("compact", func(t *testing.T) {
+				ky := &Encoder{Compact: true}
+				test(t, ky, tt.input, tt.expectCompact)
+			})
 		})
 	}
 }
@@ -2400,95 +2454,123 @@ func TestIsTypeAmbiguous(t *testing.T) {
 
 func TestRenderStringEscapes(t *testing.T) {
 	simpleCases := []struct {
-		name   string
-		input  rune
-		expect string
+		name          string
+		input         rune
+		expectRegular string
+		expectCompact string
 	}{{
-		name:   "backslash",
-		input:  '\\',
-		expect: `"\\"`,
+		name:          "backslash",
+		input:         '\\',
+		expectRegular: `"\\"`,
+		expectCompact: `"\\"`,
 	}, {
-		name:   "dquote",
-		input:  '"',
-		expect: `"\""`,
+		name:          "dquote",
+		input:         '"',
+		expectRegular: `"\""`,
+		expectCompact: `"\""`,
 	}, {
-		name:   "bell",
-		input:  '\a',
-		expect: `"\a"`,
+		name:          "bell",
+		input:         '\a',
+		expectRegular: `"\a"`,
+		expectCompact: `"\a"`,
 	}, {
-		name:   "backspace",
-		input:  '\b',
-		expect: `"\b"`,
+		name:          "backspace",
+		input:         '\b',
+		expectRegular: `"\b"`,
+		expectCompact: `"\b"`,
 	}, {
-		name:   "ff",
-		input:  '\f',
-		expect: `"\f"`,
+		name:          "ff",
+		input:         '\f',
+		expectRegular: `"\f"`,
+		expectCompact: `"\f"`,
 	}, {
-		name:   "nl",
-		input:  '\n',
-		expect: "\"\\\n \\n\\\n\"",
+		name:          "nl",
+		input:         '\n',
+		expectRegular: "\"\\\n \\n\\\n\"",
+		expectCompact: "\"\\n\"",
 	}, {
-		name:   "cr",
-		input:  '\r',
-		expect: `"\r"`,
+		name:          "cr",
+		input:         '\r',
+		expectRegular: `"\r"`,
+		expectCompact: `"\r"`,
 	}, {
-		name:   "tab",
-		input:  '\t',
-		expect: "\"\t\"",
+		name:          "tab",
+		input:         '\t',
+		expectRegular: "\"\t\"",
+		expectCompact: "\"\\t\"",
 	}, {
-		name:   "vtab",
-		input:  '\v',
-		expect: `"\v"`,
+		name:          "vtab",
+		input:         '\v',
+		expectRegular: `"\v"`,
+		expectCompact: `"\v"`,
 	}, {
-		name:   "null",
-		input:  '\x00',
-		expect: `"\0"`,
+		name:          "null",
+		input:         '\x00',
+		expectRegular: `"\0"`,
+		expectCompact: `"\0"`,
 	}, {
-		name:   "esc",
-		input:  '\x1b',
-		expect: `"\e"`,
+		name:          "esc",
+		input:         '\x1b',
+		expectRegular: `"\e"`,
+		expectCompact: `"\e"`,
 	}, {
-		name:   "nextline",
-		input:  '\u0085',
-		expect: `"\N"`,
+		name:          "nextline",
+		input:         '\u0085',
+		expectRegular: `"\N"`,
+		expectCompact: `"\N"`,
 	}, {
-		name:   "nbsp",
-		input:  '\u00a0',
-		expect: `"\_"`,
+		name:          "nbsp",
+		input:         '\u00a0',
+		expectRegular: `"\_"`,
+		expectCompact: `"\_"`,
 	}, {
-		name:   "linesep",
-		input:  '\u2028',
-		expect: `"\L"`,
+		name:          "linesep",
+		input:         '\u2028',
+		expectRegular: `"\L"`,
+		expectCompact: `"\L"`,
 	}, {
-		name:   "parasep",
-		input:  '\u2029',
-		expect: `"\P"`,
+		name:          "parasep",
+		input:         '\u2029',
+		expectRegular: `"\P"`,
+		expectCompact: `"\P"`,
 	}, {
-		name:   "x01",
-		input:  '\x01',
-		expect: `"\x01"`,
+		name:          "x01",
+		input:         '\x01',
+		expectRegular: `"\x01"`,
+		expectCompact: `"\x01"`,
 	}, {
-		name:   "uffff",
-		input:  '\uffff',
-		expect: `"\uffff"`,
+		name:          "uffff",
+		input:         '\uffff',
+		expectRegular: `"\uffff"`,
+		expectCompact: `"\uffff"`,
 	}, {
-		name:   "U0010ffff",
-		input:  '\U0010ffff',
-		expect: `"\U0010ffff"`,
+		name:          "U0010ffff",
+		input:         '\U0010ffff',
+		expectRegular: `"\U0010ffff"`,
+		expectCompact: `"\U0010ffff"`,
 	}}
+
+	test := func(t *testing.T, input string, flags flagMask, expect string) {
+		t.Helper()
+		ky := &Encoder{}
+		buf := &bytes.Buffer{}
+		err := ky.renderString(input, 0, flags, buf)
+		if err != nil {
+			t.Fatalf("renderString(%q) returned error: %v", input, err)
+		}
+		if result := buf.String(); result != expect {
+			t.Errorf("renderString(%q): want %q, got %q", input, expect, result)
+		}
+	}
 
 	for _, tt := range simpleCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ky := &Encoder{}
-			buf := &bytes.Buffer{}
-			err := ky.renderString(string(tt.input), 0, 0, buf)
-			if err != nil {
-				t.Fatalf("renderString(%q) returned error: %v", tt.input, err)
-			}
-			if result := buf.String(); result != tt.expect {
-				t.Errorf("renderString(%q): want %q, got %q", tt.input, tt.expect, result)
-			}
+			t.Run("regular", func(t *testing.T) {
+				test(t, string(tt.input), flagsNone, tt.expectRegular)
+			})
+			t.Run("compact", func(t *testing.T) {
+				test(t, string(tt.input), flagCompact, tt.expectCompact)
+			})
 		})
 	}
-
 }

--- a/kyaml/kyaml_test.go
+++ b/kyaml/kyaml_test.go
@@ -1,0 +1,1972 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kyaml
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/randfill"
+	"sigs.k8s.io/yaml"
+)
+
+// Return the input string with the longest common leading whitespace removed
+// from each line.
+func dedent(in string) string {
+	lines := strings.Split(in, "\n")
+	pfx := ""
+	for i, line := range lines {
+		if i == 0 {
+			pfx = leadingWhitespace(line)
+			continue
+		}
+		if strings.HasPrefix(line, pfx) {
+			continue
+		}
+		pfx = commonPrefix(pfx, line)
+	}
+	if pfx == "" {
+		return in
+	}
+	for i, line := range lines {
+		lines[i] = strings.TrimPrefix(line, pfx)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func leadingWhitespace(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	for i, r := range s {
+		if r != ' ' && r != '\t' {
+			return s[:i]
+		}
+	}
+	return s // all whitespace
+}
+
+func commonPrefix(a, b string) string {
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:minLen]
+}
+
+// The following types are intended to provide robust coverage for testing.
+
+type AllTypesStruct struct {
+	SimpleStruct1 `json:","`      // embedded unnamed
+	SimpleStruct2 `json:"named,"` // embedded named
+
+	// Omitted fields (`json:"-"`) are handled in a different test
+	NamedDash SimpleStruct4 `json:"-,"`
+
+	Plain            PlainStruct            `json:"plain"`
+	OmitEmpty        OmitEmptyStruct        `json:"omitEmpty"`
+	OmitZero         OmitZeroStruct         `json:"omitZero"`
+	OmitEmptyAndZero OmitEmptyAndZeroStruct `json:"omitEmptyAndZero"`
+}
+
+type SimpleStruct struct {
+	String string `json:"string"`
+	Bool   bool   `json:"bool"`
+	Int    int    `json:"int"`
+}
+type SimpleStruct1 SimpleStruct
+type SimpleStruct2 SimpleStruct
+type SimpleStruct3 SimpleStruct
+type SimpleStruct4 SimpleStruct
+
+type PlainStruct struct {
+	// Basic types
+	String  string    `json:"string"`
+	Bool    bool      `json:"bool"`
+	Int     int       `json:"int"`
+	Int8    int8      `json:"int8"`
+	Int16   int16     `json:"int16"`
+	Int32   int32     `json:"int32"`
+	Int64   int64     `json:"int64"`
+	Uint    uint      `json:"uint"`
+	Uint8   uint8     `json:"uint8"`
+	Uint16  uint16    `json:"uint16"`
+	Uint32  uint32    `json:"uint32"`
+	Uint64  uint64    `json:"uint64"`
+	Float32 float32   `json:"float32"`
+	Float64 float64   `json:"float64"`
+	Time    time.Time `json:"time"`
+	Bytes   []byte    `json:"bytes"`
+
+	// Pointers to basic types
+	StringPtr  *string    `json:"stringPtr"`
+	BoolPtr    *bool      `json:"boolPtr"`
+	IntPtr     *int       `json:"intPtr"`
+	Int8Ptr    *int8      `json:"int8Ptr"`
+	Int16Ptr   *int16     `json:"int16Ptr"`
+	Int32Ptr   *int32     `json:"int32Ptr"`
+	Int64Ptr   *int64     `json:"int64Ptr"`
+	UintPtr    *uint      `json:"uintPtr"`
+	Uint8Ptr   *uint8     `json:"uint8Ptr"`
+	Uint16Ptr  *uint16    `json:"uint16Ptr"`
+	Uint32Ptr  *uint32    `json:"uint32Ptr"`
+	Uint64Ptr  *uint64    `json:"uint64Ptr"`
+	Float32Ptr *float32   `json:"float32Ptr"`
+	Float64Ptr *float64   `json:"float64Ptr"`
+	TimePtr    *time.Time `json:"timePtr,omitempty"` // Time implements json.Marshaler, but on a value receiver
+
+	// Slices of basic types
+	StringSlice  []string    `json:"stringSlice"`
+	BoolSlice    []bool      `json:"boolSlice"`
+	IntSlice     []int       `json:"intSlice"`
+	Int8Slice    []int8      `json:"int8Slice"`
+	Int16Slice   []int16     `json:"int16Slice"`
+	Int32Slice   []int32     `json:"int32Slice"`
+	Int64Slice   []int64     `json:"int64Slice"`
+	UintSlice    []uint      `json:"uintSlice"`
+	Uint8Slice   []uint8     `json:"uint8Slice"`
+	Uint16Slice  []uint16    `json:"uint16Slice"`
+	Uint32Slice  []uint32    `json:"uint32Slice"`
+	Uint64Slice  []uint64    `json:"uint64Slice"`
+	Float32Slice []float32   `json:"float32Slice"`
+	Float64Slice []float64   `json:"float64Slice"`
+	TimeSlice    []time.Time `json:"timeSlice"`
+
+	// Maps of string to basic types
+	StringMap  map[string]string    `json:"stringMap"`
+	BoolMap    map[string]bool      `json:"boolMap"`
+	IntMap     map[string]int       `json:"intMap"`
+	Int8Map    map[string]int8      `json:"int8Map"`
+	Int16Map   map[string]int16     `json:"int16Map"`
+	Int32Map   map[string]int32     `json:"int32Map"`
+	Int64Map   map[string]int64     `json:"int64Map"`
+	UintMap    map[string]uint      `json:"uintMap"`
+	Uint8Map   map[string]uint8     `json:"uint8Map"`
+	Uint16Map  map[string]uint16    `json:"uint16Map"`
+	Uint32Map  map[string]uint32    `json:"uint32Map"`
+	Uint64Map  map[string]uint64    `json:"uint64Map"`
+	Float32Map map[string]float32   `json:"float32Map"`
+	Float64Map map[string]float64   `json:"float64Map"`
+	TimeMap    map[string]time.Time `json:"timeMap"`
+
+	// Slice of slices
+	StringSliceSlice  [][]string    `json:"stringSliceSlice"`
+	BoolSliceSlice    [][]bool      `json:"boolSliceSlice"`
+	IntSliceSlice     [][]int       `json:"intSliceSlice"`
+	Int8SliceSlice    [][]int8      `json:"int8SliceSlice"`
+	Int16SliceSlice   [][]int16     `json:"int16SliceSlice"`
+	Int32SliceSlice   [][]int32     `json:"int32SliceSlice"`
+	Int64SliceSlice   [][]int64     `json:"int64SliceSlice"`
+	UintSliceSlice    [][]uint      `json:"uintSliceSlice"`
+	Uint8SliceSlice   [][]uint8     `json:"uint8SliceSlice"`
+	Uint16SliceSlice  [][]uint16    `json:"uint16SliceSlice"`
+	Uint32SliceSlice  [][]uint32    `json:"uint32SliceSlice"`
+	Uint64SliceSlice  [][]uint64    `json:"uint64SliceSlice"`
+	Float32SliceSlice [][]float32   `json:"float32SliceSlice"`
+	Float64SliceSlice [][]float64   `json:"float64SliceSlice"`
+	TimeSliceSlice    [][]time.Time `json:"timeSliceSlice"`
+
+	// Slice of maps
+	StringSliceMap  []map[string]string    `json:"stringSliceMap"`
+	BoolSliceMap    []map[string]bool      `json:"boolSliceMap"`
+	IntSliceMap     []map[string]int       `json:"intSliceMap"`
+	Int8SliceMap    []map[string]int8      `json:"int8SliceMap"`
+	Int16SliceMap   []map[string]int16     `json:"int16SliceMap"`
+	Int32SliceMap   []map[string]int32     `json:"int32SliceMap"`
+	Int64SliceMap   []map[string]int64     `json:"int64SliceMap"`
+	UintSliceMap    []map[string]uint      `json:"uintSliceMap"`
+	Uint8SliceMap   []map[string]uint8     `json:"uint8SliceMap"`
+	Uint16SliceMap  []map[string]uint16    `json:"uint16SliceMap"`
+	Uint32SliceMap  []map[string]uint32    `json:"uint32SliceMap"`
+	Uint64SliceMap  []map[string]uint64    `json:"uint64SliceMap"`
+	Float32SliceMap []map[string]float32   `json:"float32SliceMap"`
+	Float64SliceMap []map[string]float64   `json:"float64SliceMap"`
+	TimeSliceMap    []map[string]time.Time `json:"timeSliceMap"`
+
+	// Map of string to slices
+	StringMapSlice  map[string][]string    `json:"stringMapSlice"`
+	BoolMapSlice    map[string][]bool      `json:"boolMapSlice"`
+	IntMapSlice     map[string][]int       `json:"intMapSlice"`
+	Int8MapSlice    map[string][]int8      `json:"int8MapSlice"`
+	Int16MapSlice   map[string][]int16     `json:"int16MapSlice"`
+	Int32MapSlice   map[string][]int32     `json:"int32MapSlice"`
+	Int64MapSlice   map[string][]int64     `json:"int64MapSlice"`
+	UintMapSlice    map[string][]uint      `json:"uintMapSlice"`
+	Uint8MapSlice   map[string][]uint8     `json:"uint8MapSlice"`
+	Uint16MapSlice  map[string][]uint16    `json:"uint16MapSlice"`
+	Uint32MapSlice  map[string][]uint32    `json:"uint32MapSlice"`
+	Uint64MapSlice  map[string][]uint64    `json:"uint64MapSlice"`
+	Float32MapSlice map[string][]float32   `json:"float32MapSlice"`
+	Float64MapSlice map[string][]float64   `json:"float64MapSlice"`
+	TimeMapSlice    map[string][]time.Time `json:"timeMapSlice"`
+
+	// Map of string to maps
+	StringMapMap  map[string]map[string]string    `json:"stringMapMap"`
+	BoolMapMap    map[string]map[string]bool      `json:"boolMapMap"`
+	IntMapMap     map[string]map[string]int       `json:"intMapMap"`
+	Int8MapMap    map[string]map[string]int8      `json:"int8MapMap"`
+	Int16MapMap   map[string]map[string]int16     `json:"int16MapMap"`
+	Int32MapMap   map[string]map[string]int32     `json:"int32MapMap"`
+	Int64MapMap   map[string]map[string]int64     `json:"int64MapMap"`
+	UintMapMap    map[string]map[string]uint      `json:"uintMapMap"`
+	Uint8MapMap   map[string]map[string]uint8     `json:"uint8MapMap"`
+	Uint16MapMap  map[string]map[string]uint16    `json:"uint16MapMap"`
+	Uint32MapMap  map[string]map[string]uint32    `json:"uint32MapMap"`
+	Uint64MapMap  map[string]map[string]uint64    `json:"uint64MapMap"`
+	Float32MapMap map[string]map[string]float32   `json:"float32MapMap"`
+	Float64MapMap map[string]map[string]float64   `json:"float64MapMap"`
+	TimeMapMap    map[string]map[string]time.Time `json:"timeMapMap"`
+
+	// Recursive types
+	Self           *PlainStruct                       `json:"self"`
+	SelfSlice      []*PlainStruct                     `json:"selfSlice"`
+	SelfMap        map[string]*PlainStruct            `json:"selfMap"`
+	SelfSliceSlice [][](*PlainStruct)                 `json:"selfSliceSlice"`
+	SelfSliceMap   []map[string]*PlainStruct          `json:"selfSliceMap"`
+	SelfMapSlice   map[string][]*PlainStruct          `json:"selfMapSlice"`
+	SelfMapMap     map[string]map[string]*PlainStruct `json:"selfMapMap"`
+}
+
+type OmitEmptyStruct struct {
+	// Basic types
+	String  string    `json:"string,omitempty"`
+	Bool    bool      `json:"bool,omitempty"`
+	Int     int       `json:"int,omitempty"`
+	Int8    int8      `json:"int8,omitempty"`
+	Int16   int16     `json:"int16,omitempty"`
+	Int32   int32     `json:"int32,omitempty"`
+	Int64   int64     `json:"int64,omitempty"`
+	Uint    uint      `json:"uint,omitempty"`
+	Uint8   uint8     `json:"uint8,omitempty"`
+	Uint16  uint16    `json:"uint16,omitempty"`
+	Uint32  uint32    `json:"uint32,omitempty"`
+	Uint64  uint64    `json:"uint64,omitempty"`
+	Float32 float32   `json:"float32,omitempty"`
+	Float64 float64   `json:"float64,omitempty"`
+	Time    time.Time `json:"time,omitempty"`
+	Bytes   []byte    `json:"bytes,omitempty"`
+
+	// Pointers to basic types
+	StringPtr  *string    `json:"stringPtr,omitempty"`
+	BoolPtr    *bool      `json:"boolPtr,omitempty"`
+	IntPtr     *int       `json:"intPtr,omitempty"`
+	Int8Ptr    *int8      `json:"int8Ptr,omitempty"`
+	Int16Ptr   *int16     `json:"int16Ptr,omitempty"`
+	Int32Ptr   *int32     `json:"int32Ptr,omitempty"`
+	Int64Ptr   *int64     `json:"int64Ptr,omitempty"`
+	UintPtr    *uint      `json:"uintPtr,omitempty"`
+	Uint8Ptr   *uint8     `json:"uint8Ptr,omitempty"`
+	Uint16Ptr  *uint16    `json:"uint16Ptr,omitempty"`
+	Uint32Ptr  *uint32    `json:"uint32Ptr,omitempty"`
+	Uint64Ptr  *uint64    `json:"uint64Ptr,omitempty"`
+	Float32Ptr *float32   `json:"float32Ptr,omitempty"`
+	Float64Ptr *float64   `json:"float64Ptr,omitempty"`
+	TimePtr    *time.Time `json:"timePtr,omitempty"`
+
+	// Slices of basic types
+	StringSlice  []string    `json:"stringSlice,omitempty"`
+	BoolSlice    []bool      `json:"boolSlice,omitempty"`
+	IntSlice     []int       `json:"intSlice,omitempty"`
+	Int8Slice    []int8      `json:"int8Slice,omitempty"`
+	Int16Slice   []int16     `json:"int16Slice,omitempty"`
+	Int32Slice   []int32     `json:"int32Slice,omitempty"`
+	Int64Slice   []int64     `json:"int64Slice,omitempty"`
+	UintSlice    []uint      `json:"uintSlice,omitempty"`
+	Uint8Slice   []uint8     `json:"uint8Slice,omitempty"`
+	Uint16Slice  []uint16    `json:"uint16Slice,omitempty"`
+	Uint32Slice  []uint32    `json:"uint32Slice,omitempty"`
+	Uint64Slice  []uint64    `json:"uint64Slice,omitempty"`
+	Float32Slice []float32   `json:"float32Slice,omitempty"`
+	Float64Slice []float64   `json:"float64Slice,omitempty"`
+	TimeSlice    []time.Time `json:"timeSlice,omitempty"`
+
+	// Maps of string to basic types
+	StringMap  map[string]string    `json:"stringMap,omitempty"`
+	BoolMap    map[string]bool      `json:"boolMap,omitempty"`
+	IntMap     map[string]int       `json:"intMap,omitempty"`
+	Int8Map    map[string]int8      `json:"int8Map,omitempty"`
+	Int16Map   map[string]int16     `json:"int16Map,omitempty"`
+	Int32Map   map[string]int32     `json:"int32Map,omitempty"`
+	Int64Map   map[string]int64     `json:"int64Map,omitempty"`
+	UintMap    map[string]uint      `json:"uintMap,omitempty"`
+	Uint8Map   map[string]uint8     `json:"uint8Map,omitempty"`
+	Uint16Map  map[string]uint16    `json:"uint16Map,omitempty"`
+	Uint32Map  map[string]uint32    `json:"uint32Map,omitempty"`
+	Uint64Map  map[string]uint64    `json:"uint64Map,omitempty"`
+	Float32Map map[string]float32   `json:"float32Map,omitempty"`
+	Float64Map map[string]float64   `json:"float64Map,omitempty"`
+	TimeMap    map[string]time.Time `json:"timeMap,omitempty"`
+
+	// Slice of slices
+	StringSliceSlice  [][]string    `json:"stringSliceSlice,omitempty"`
+	BoolSliceSlice    [][]bool      `json:"boolSliceSlice,omitempty"`
+	IntSliceSlice     [][]int       `json:"intSliceSlice,omitempty"`
+	Int8SliceSlice    [][]int8      `json:"int8SliceSlice,omitempty"`
+	Int16SliceSlice   [][]int16     `json:"int16SliceSlice,omitempty"`
+	Int32SliceSlice   [][]int32     `json:"int32SliceSlice,omitempty"`
+	Int64SliceSlice   [][]int64     `json:"int64SliceSlice,omitempty"`
+	UintSliceSlice    [][]uint      `json:"uintSliceSlice,omitempty"`
+	Uint8SliceSlice   [][]uint8     `json:"uint8SliceSlice,omitempty"`
+	Uint16SliceSlice  [][]uint16    `json:"uint16SliceSlice,omitempty"`
+	Uint32SliceSlice  [][]uint32    `json:"uint32SliceSlice,omitempty"`
+	Uint64SliceSlice  [][]uint64    `json:"uint64SliceSlice,omitempty"`
+	Float32SliceSlice [][]float32   `json:"float32SliceSlice,omitempty"`
+	Float64SliceSlice [][]float64   `json:"float64SliceSlice,omitempty"`
+	TimeSliceSlice    [][]time.Time `json:"timeSliceSlice,omitempty"`
+
+	// Slice of maps
+	StringSliceMap  []map[string]string    `json:"stringSliceMap,omitempty"`
+	BoolSliceMap    []map[string]bool      `json:"boolSliceMap,omitempty"`
+	IntSliceMap     []map[string]int       `json:"intSliceMap,omitempty"`
+	Int8SliceMap    []map[string]int8      `json:"int8SliceMap,omitempty"`
+	Int16SliceMap   []map[string]int16     `json:"int16SliceMap,omitempty"`
+	Int32SliceMap   []map[string]int32     `json:"int32SliceMap,omitempty"`
+	Int64SliceMap   []map[string]int64     `json:"int64SliceMap,omitempty"`
+	UintSliceMap    []map[string]uint      `json:"uintSliceMap,omitempty"`
+	Uint8SliceMap   []map[string]uint8     `json:"uint8SliceMap,omitempty"`
+	Uint16SliceMap  []map[string]uint16    `json:"uint16SliceMap,omitempty"`
+	Uint32SliceMap  []map[string]uint32    `json:"uint32SliceMap,omitempty"`
+	Uint64SliceMap  []map[string]uint64    `json:"uint64SliceMap,omitempty"`
+	Float32SliceMap []map[string]float32   `json:"float32SliceMap,omitempty"`
+	Float64SliceMap []map[string]float64   `json:"float64SliceMap,omitempty"`
+	TimeSliceMap    []map[string]time.Time `json:"timeSliceMap,omitempty"`
+
+	// Map of string to slices
+	StringMapSlice  map[string][]string    `json:"stringMapSlice,omitempty"`
+	BoolMapSlice    map[string][]bool      `json:"boolMapSlice,omitempty"`
+	IntMapSlice     map[string][]int       `json:"intMapSlice,omitempty"`
+	Int8MapSlice    map[string][]int8      `json:"int8MapSlice,omitempty"`
+	Int16MapSlice   map[string][]int16     `json:"int16MapSlice,omitempty"`
+	Int32MapSlice   map[string][]int32     `json:"int32MapSlice,omitempty"`
+	Int64MapSlice   map[string][]int64     `json:"int64MapSlice,omitempty"`
+	UintMapSlice    map[string][]uint      `json:"uintMapSlice,omitempty"`
+	Uint8MapSlice   map[string][]uint8     `json:"uint8MapSlice,omitempty"`
+	Uint16MapSlice  map[string][]uint16    `json:"uint16MapSlice,omitempty"`
+	Uint32MapSlice  map[string][]uint32    `json:"uint32MapSlice,omitempty"`
+	Uint64MapSlice  map[string][]uint64    `json:"uint64MapSlice,omitempty"`
+	Float32MapSlice map[string][]float32   `json:"float32MapSlice,omitempty"`
+	Float64MapSlice map[string][]float64   `json:"float64MapSlice,omitempty"`
+	TimeMapSlice    map[string][]time.Time `json:"timeMapSlice,omitempty"`
+
+	// Map of string to maps
+	StringMapMap  map[string]map[string]string    `json:"stringMapMap,omitempty"`
+	BoolMapMap    map[string]map[string]bool      `json:"boolMapMap,omitempty"`
+	IntMapMap     map[string]map[string]int       `json:"intMapMap,omitempty"`
+	Int8MapMap    map[string]map[string]int8      `json:"int8MapMap,omitempty"`
+	Int16MapMap   map[string]map[string]int16     `json:"int16MapMap,omitempty"`
+	Int32MapMap   map[string]map[string]int32     `json:"int32MapMap,omitempty"`
+	Int64MapMap   map[string]map[string]int64     `json:"int64MapMap,omitempty"`
+	UintMapMap    map[string]map[string]uint      `json:"uintMapMap,omitempty"`
+	Uint8MapMap   map[string]map[string]uint8     `json:"uint8MapMap,omitempty"`
+	Uint16MapMap  map[string]map[string]uint16    `json:"uint16MapMap,omitempty"`
+	Uint32MapMap  map[string]map[string]uint32    `json:"uint32MapMap,omitempty"`
+	Uint64MapMap  map[string]map[string]uint64    `json:"uint64MapMap,omitempty"`
+	Float32MapMap map[string]map[string]float32   `json:"float32MapMap,omitempty"`
+	Float64MapMap map[string]map[string]float64   `json:"float64MapMap,omitempty"`
+	TimeMapMap    map[string]map[string]time.Time `json:"timeMapMap,omitempty"`
+
+	// Recursive types
+	Self           *OmitEmptyStruct                       `json:"self,omitempty"`
+	SelfSlice      []*OmitEmptyStruct                     `json:"selfSlice,omitempty"`
+	SelfMap        map[string]*OmitEmptyStruct            `json:"selfMap,omitempty"`
+	SelfSliceSlice [][](*OmitEmptyStruct)                 `json:"selfSliceSlice,omitempty"`
+	SelfSliceMap   []map[string]*OmitEmptyStruct          `json:"selfSliceMap,omitempty"`
+	SelfMapSlice   map[string][]*OmitEmptyStruct          `json:"selfMapSlice,omitempty"`
+	SelfMapMap     map[string]map[string]*OmitEmptyStruct `json:"selfMapMap,omitempty"`
+}
+
+type OmitZeroStruct struct {
+	// Basic types
+	String  string    `json:"string,omitzero"`
+	Bool    bool      `json:"bool,omitzero"`
+	Int     int       `json:"int,omitzero"`
+	Int8    int8      `json:"int8,omitzero"`
+	Int16   int16     `json:"int16,omitzero"`
+	Int32   int32     `json:"int32,omitzero"`
+	Int64   int64     `json:"int64,omitzero"`
+	Uint    uint      `json:"uint,omitzero"`
+	Uint8   uint8     `json:"uint8,omitzero"`
+	Uint16  uint16    `json:"uint16,omitzero"`
+	Uint32  uint32    `json:"uint32,omitzero"`
+	Uint64  uint64    `json:"uint64,omitzero"`
+	Float32 float32   `json:"float32,omitzero"`
+	Float64 float64   `json:"float64,omitzero"`
+	Time    time.Time `json:"time,omitzero"`
+	Bytes   []byte    `json:"bytes,omitzero"`
+
+	// Pointers to basic types
+	StringPtr  *string    `json:"stringPtr,omitzero"`
+	BoolPtr    *bool      `json:"boolPtr,omitzero"`
+	IntPtr     *int       `json:"intPtr,omitzero"`
+	Int8Ptr    *int8      `json:"int8Ptr,omitzero"`
+	Int16Ptr   *int16     `json:"int16Ptr,omitzero"`
+	Int32Ptr   *int32     `json:"int32Ptr,omitzero"`
+	Int64Ptr   *int64     `json:"int64Ptr,omitzero"`
+	UintPtr    *uint      `json:"uintPtr,omitzero"`
+	Uint8Ptr   *uint8     `json:"uint8Ptr,omitzero"`
+	Uint16Ptr  *uint16    `json:"uint16Ptr,omitzero"`
+	Uint32Ptr  *uint32    `json:"uint32Ptr,omitzero"`
+	Uint64Ptr  *uint64    `json:"uint64Ptr,omitzero"`
+	Float32Ptr *float32   `json:"float32Ptr,omitzero"`
+	Float64Ptr *float64   `json:"float64Ptr,omitzero"`
+	TimePtr    *time.Time `json:"timePtr,omitzero"`
+
+	// Slices of basic types
+	StringSlice  []string    `json:"stringSlice,omitzero"`
+	BoolSlice    []bool      `json:"boolSlice,omitzero"`
+	IntSlice     []int       `json:"intSlice,omitzero"`
+	Int8Slice    []int8      `json:"int8Slice,omitzero"`
+	Int16Slice   []int16     `json:"int16Slice,omitzero"`
+	Int32Slice   []int32     `json:"int32Slice,omitzero"`
+	Int64Slice   []int64     `json:"int64Slice,omitzero"`
+	UintSlice    []uint      `json:"uintSlice,omitzero"`
+	Uint8Slice   []uint8     `json:"uint8Slice,omitzero"`
+	Uint16Slice  []uint16    `json:"uint16Slice,omitzero"`
+	Uint32Slice  []uint32    `json:"uint32Slice,omitzero"`
+	Uint64Slice  []uint64    `json:"uint64Slice,omitzero"`
+	Float32Slice []float32   `json:"float32Slice,omitzero"`
+	Float64Slice []float64   `json:"float64Slice,omitzero"`
+	TimeSlice    []time.Time `json:"timeSlice,omitzero"`
+
+	// Maps of string to basic types
+	StringMap  map[string]string    `json:"stringMap,omitzero"`
+	BoolMap    map[string]bool      `json:"boolMap,omitzero"`
+	IntMap     map[string]int       `json:"intMap,omitzero"`
+	Int8Map    map[string]int8      `json:"int8Map,omitzero"`
+	Int16Map   map[string]int16     `json:"int16Map,omitzero"`
+	Int32Map   map[string]int32     `json:"int32Map,omitzero"`
+	Int64Map   map[string]int64     `json:"int64Map,omitzero"`
+	UintMap    map[string]uint      `json:"uintMap,omitzero"`
+	Uint8Map   map[string]uint8     `json:"uint8Map,omitzero"`
+	Uint16Map  map[string]uint16    `json:"uint16Map,omitzero"`
+	Uint32Map  map[string]uint32    `json:"uint32Map,omitzero"`
+	Uint64Map  map[string]uint64    `json:"uint64Map,omitzero"`
+	Float32Map map[string]float32   `json:"float32Map,omitzero"`
+	Float64Map map[string]float64   `json:"float64Map,omitzero"`
+	TimeMap    map[string]time.Time `json:"timeMap,omitzero"`
+
+	// Slice of slices
+	StringSliceSlice  [][]string    `json:"stringSliceSlice,omitzero"`
+	BoolSliceSlice    [][]bool      `json:"boolSliceSlice,omitzero"`
+	IntSliceSlice     [][]int       `json:"intSliceSlice,omitzero"`
+	Int8SliceSlice    [][]int8      `json:"int8SliceSlice,omitzero"`
+	Int16SliceSlice   [][]int16     `json:"int16SliceSlice,omitzero"`
+	Int32SliceSlice   [][]int32     `json:"int32SliceSlice,omitzero"`
+	Int64SliceSlice   [][]int64     `json:"int64SliceSlice,omitzero"`
+	UintSliceSlice    [][]uint      `json:"uintSliceSlice,omitzero"`
+	Uint8SliceSlice   [][]uint8     `json:"uint8SliceSlice,omitzero"`
+	Uint16SliceSlice  [][]uint16    `json:"uint16SliceSlice,omitzero"`
+	Uint32SliceSlice  [][]uint32    `json:"uint32SliceSlice,omitzero"`
+	Uint64SliceSlice  [][]uint64    `json:"uint64SliceSlice,omitzero"`
+	Float32SliceSlice [][]float32   `json:"float32SliceSlice,omitzero"`
+	Float64SliceSlice [][]float64   `json:"float64SliceSlice,omitzero"`
+	TimeSliceSlice    [][]time.Time `json:"timeSliceSlice,omitzero"`
+
+	// Slice of maps
+	StringSliceMap  []map[string]string    `json:"stringSliceMap,omitzero"`
+	BoolSliceMap    []map[string]bool      `json:"boolSliceMap,omitzero"`
+	IntSliceMap     []map[string]int       `json:"intSliceMap,omitzero"`
+	Int8SliceMap    []map[string]int8      `json:"int8SliceMap,omitzero"`
+	Int16SliceMap   []map[string]int16     `json:"int16SliceMap,omitzero"`
+	Int32SliceMap   []map[string]int32     `json:"int32SliceMap,omitzero"`
+	Int64SliceMap   []map[string]int64     `json:"int64SliceMap,omitzero"`
+	UintSliceMap    []map[string]uint      `json:"uintSliceMap,omitzero"`
+	Uint8SliceMap   []map[string]uint8     `json:"uint8SliceMap,omitzero"`
+	Uint16SliceMap  []map[string]uint16    `json:"uint16SliceMap,omitzero"`
+	Uint32SliceMap  []map[string]uint32    `json:"uint32SliceMap,omitzero"`
+	Uint64SliceMap  []map[string]uint64    `json:"uint64SliceMap,omitzero"`
+	Float32SliceMap []map[string]float32   `json:"float32SliceMap,omitzero"`
+	Float64SliceMap []map[string]float64   `json:"float64SliceMap,omitzero"`
+	TimeSliceMap    []map[string]time.Time `json:"timeSliceMap,omitzero"`
+
+	// Map of string to slices
+	StringMapSlice  map[string][]string    `json:"stringMapSlice,omitzero"`
+	BoolMapSlice    map[string][]bool      `json:"boolMapSlice,omitzero"`
+	IntMapSlice     map[string][]int       `json:"intMapSlice,omitzero"`
+	Int8MapSlice    map[string][]int8      `json:"int8MapSlice,omitzero"`
+	Int16MapSlice   map[string][]int16     `json:"int16MapSlice,omitzero"`
+	Int32MapSlice   map[string][]int32     `json:"int32MapSlice,omitzero"`
+	Int64MapSlice   map[string][]int64     `json:"int64MapSlice,omitzero"`
+	UintMapSlice    map[string][]uint      `json:"uintMapSlice,omitzero"`
+	Uint8MapSlice   map[string][]uint8     `json:"uint8MapSlice,omitzero"`
+	Uint16MapSlice  map[string][]uint16    `json:"uint16MapSlice,omitzero"`
+	Uint32MapSlice  map[string][]uint32    `json:"uint32MapSlice,omitzero"`
+	Uint64MapSlice  map[string][]uint64    `json:"uint64MapSlice,omitzero"`
+	Float32MapSlice map[string][]float32   `json:"float32MapSlice,omitzero"`
+	Float64MapSlice map[string][]float64   `json:"float64MapSlice,omitzero"`
+	TimeMapSlice    map[string][]time.Time `json:"timeMapSlice,omitzero"`
+
+	// Map of string to maps
+	StringMapMap  map[string]map[string]string    `json:"stringMapMap,omitzero"`
+	BoolMapMap    map[string]map[string]bool      `json:"boolMapMap,omitzero"`
+	IntMapMap     map[string]map[string]int       `json:"intMapMap,omitzero"`
+	Int8MapMap    map[string]map[string]int8      `json:"int8MapMap,omitzero"`
+	Int16MapMap   map[string]map[string]int16     `json:"int16MapMap,omitzero"`
+	Int32MapMap   map[string]map[string]int32     `json:"int32MapMap,omitzero"`
+	Int64MapMap   map[string]map[string]int64     `json:"int64MapMap,omitzero"`
+	UintMapMap    map[string]map[string]uint      `json:"uintMapMap,omitzero"`
+	Uint8MapMap   map[string]map[string]uint8     `json:"uint8MapMap,omitzero"`
+	Uint16MapMap  map[string]map[string]uint16    `json:"uint16MapMap,omitzero"`
+	Uint32MapMap  map[string]map[string]uint32    `json:"uint32MapMap,omitzero"`
+	Uint64MapMap  map[string]map[string]uint64    `json:"uint64MapMap,omitzero"`
+	Float32MapMap map[string]map[string]float32   `json:"float32MapMap,omitzero"`
+	Float64MapMap map[string]map[string]float64   `json:"float64MapMap,omitzero"`
+	TimeMapMap    map[string]map[string]time.Time `json:"timeMapMap,omitzero"`
+
+	// Recursive types
+	Self           *OmitZeroStruct                       `json:"self,omitzero"`
+	SelfSlice      []*OmitZeroStruct                     `json:"selfSlice,omitzero"`
+	SelfMap        map[string]*OmitZeroStruct            `json:"selfMap,omitzero"`
+	SelfSliceSlice [][](*OmitZeroStruct)                 `json:"selfSliceSlice,omitzero"`
+	SelfSliceMap   []map[string]*OmitZeroStruct          `json:"selfSliceMap,omitzero"`
+	SelfMapSlice   map[string][]*OmitZeroStruct          `json:"selfMapSlice,omitzero"`
+	SelfMapMap     map[string]map[string]*OmitZeroStruct `json:"selfMapMap,omitzero"`
+}
+
+type OmitEmptyAndZeroStruct struct {
+	// Basic types
+	String  string    `json:"string,omitempty,omitzero"`
+	Bool    bool      `json:"bool,omitempty,omitzero"`
+	Int     int       `json:"int,omitempty,omitzero"`
+	Int8    int8      `json:"int8,omitempty,omitzero"`
+	Int16   int16     `json:"int16,omitempty,omitzero"`
+	Int32   int32     `json:"int32,omitempty,omitzero"`
+	Int64   int64     `json:"int64,omitempty,omitzero"`
+	Uint    uint      `json:"uint,omitempty,omitzero"`
+	Uint8   uint8     `json:"uint8,omitempty,omitzero"`
+	Uint16  uint16    `json:"uint16,omitempty,omitzero"`
+	Uint32  uint32    `json:"uint32,omitempty,omitzero"`
+	Uint64  uint64    `json:"uint64,omitempty,omitzero"`
+	Float32 float32   `json:"float32,omitempty,omitzero"`
+	Float64 float64   `json:"float64,omitempty,omitzero"`
+	Time    time.Time `json:"time,omitempty,omitzero"`
+	Bytes   []byte    `json:"bytes,omitempty,omitzero"`
+
+	// Pointers to basic types
+	StringPtr  *string    `json:"stringPtr,omitempty,omitzero"`
+	BoolPtr    *bool      `json:"boolPtr,omitempty,omitzero"`
+	IntPtr     *int       `json:"intPtr,omitempty,omitzero"`
+	Int8Ptr    *int8      `json:"int8Ptr,omitempty,omitzero"`
+	Int16Ptr   *int16     `json:"int16Ptr,omitempty,omitzero"`
+	Int32Ptr   *int32     `json:"int32Ptr,omitempty,omitzero"`
+	Int64Ptr   *int64     `json:"int64Ptr,omitempty,omitzero"`
+	UintPtr    *uint      `json:"uintPtr,omitempty,omitzero"`
+	Uint8Ptr   *uint8     `json:"uint8Ptr,omitempty,omitzero"`
+	Uint16Ptr  *uint16    `json:"uint16Ptr,omitempty,omitzero"`
+	Uint32Ptr  *uint32    `json:"uint32Ptr,omitempty,omitzero"`
+	Uint64Ptr  *uint64    `json:"uint64Ptr,omitempty,omitzero"`
+	Float32Ptr *float32   `json:"float32Ptr,omitempty,omitzero"`
+	Float64Ptr *float64   `json:"float64Ptr,omitempty,omitzero"`
+	TimePtr    *time.Time `json:"timePtr,omitempty,omitzero"`
+
+	// Slices of basic types
+	StringSlice  []string    `json:"stringSlice,omitempty,omitzero"`
+	BoolSlice    []bool      `json:"boolSlice,omitempty,omitzero"`
+	IntSlice     []int       `json:"intSlice,omitempty,omitzero"`
+	Int8Slice    []int8      `json:"int8Slice,omitempty,omitzero"`
+	Int16Slice   []int16     `json:"int16Slice,omitempty,omitzero"`
+	Int32Slice   []int32     `json:"int32Slice,omitempty,omitzero"`
+	Int64Slice   []int64     `json:"int64Slice,omitempty,omitzero"`
+	UintSlice    []uint      `json:"uintSlice,omitempty,omitzero"`
+	Uint8Slice   []uint8     `json:"uint8Slice,omitempty,omitzero"`
+	Uint16Slice  []uint16    `json:"uint16Slice,omitempty,omitzero"`
+	Uint32Slice  []uint32    `json:"uint32Slice,omitempty,omitzero"`
+	Uint64Slice  []uint64    `json:"uint64Slice,omitempty,omitzero"`
+	Float32Slice []float32   `json:"float32Slice,omitempty,omitzero"`
+	Float64Slice []float64   `json:"float64Slice,omitempty,omitzero"`
+	TimeSlice    []time.Time `json:"timeSlice,omitempty,omitzero"`
+
+	// Maps of string to basic types
+	StringMap  map[string]string    `json:"stringMap,omitempty,omitzero"`
+	BoolMap    map[string]bool      `json:"boolMap,omitempty,omitzero"`
+	IntMap     map[string]int       `json:"intMap,omitempty,omitzero"`
+	Int8Map    map[string]int8      `json:"int8Map,omitempty,omitzero"`
+	Int16Map   map[string]int16     `json:"int16Map,omitempty,omitzero"`
+	Int32Map   map[string]int32     `json:"int32Map,omitempty,omitzero"`
+	Int64Map   map[string]int64     `json:"int64Map,omitempty,omitzero"`
+	UintMap    map[string]uint      `json:"uintMap,omitempty,omitzero"`
+	Uint8Map   map[string]uint8     `json:"uint8Map,omitempty,omitzero"`
+	Uint16Map  map[string]uint16    `json:"uint16Map,omitempty,omitzero"`
+	Uint32Map  map[string]uint32    `json:"uint32Map,omitempty,omitzero"`
+	Uint64Map  map[string]uint64    `json:"uint64Map,omitempty,omitzero"`
+	Float32Map map[string]float32   `json:"float32Map,omitempty,omitzero"`
+	Float64Map map[string]float64   `json:"float64Map,omitempty,omitzero"`
+	TimeMap    map[string]time.Time `json:"timeMap,omitempty,omitzero"`
+
+	// Slice of slices
+	StringSliceSlice  [][]string    `json:"stringSliceSlice,omitempty,omitzero"`
+	BoolSliceSlice    [][]bool      `json:"boolSliceSlice,omitempty,omitzero"`
+	IntSliceSlice     [][]int       `json:"intSliceSlice,omitempty,omitzero"`
+	Int8SliceSlice    [][]int8      `json:"int8SliceSlice,omitempty,omitzero"`
+	Int16SliceSlice   [][]int16     `json:"int16SliceSlice,omitempty,omitzero"`
+	Int32SliceSlice   [][]int32     `json:"int32SliceSlice,omitempty,omitzero"`
+	Int64SliceSlice   [][]int64     `json:"int64SliceSlice,omitempty,omitzero"`
+	UintSliceSlice    [][]uint      `json:"uintSliceSlice,omitempty,omitzero"`
+	Uint8SliceSlice   [][]uint8     `json:"uint8SliceSlice,omitempty,omitzero"`
+	Uint16SliceSlice  [][]uint16    `json:"uint16SliceSlice,omitempty,omitzero"`
+	Uint32SliceSlice  [][]uint32    `json:"uint32SliceSlice,omitempty,omitzero"`
+	Uint64SliceSlice  [][]uint64    `json:"uint64SliceSlice,omitempty,omitzero"`
+	Float32SliceSlice [][]float32   `json:"float32SliceSlice,omitempty,omitzero"`
+	Float64SliceSlice [][]float64   `json:"float64SliceSlice,omitempty,omitzero"`
+	TimeSliceSlice    [][]time.Time `json:"timeSliceSlice,omitempty,omitzero"`
+
+	// Slice of maps
+	StringSliceMap  []map[string]string    `json:"stringSliceMap,omitempty,omitzero"`
+	BoolSliceMap    []map[string]bool      `json:"boolSliceMap,omitempty,omitzero"`
+	IntSliceMap     []map[string]int       `json:"intSliceMap,omitempty,omitzero"`
+	Int8SliceMap    []map[string]int8      `json:"int8SliceMap,omitempty,omitzero"`
+	Int16SliceMap   []map[string]int16     `json:"int16SliceMap,omitempty,omitzero"`
+	Int32SliceMap   []map[string]int32     `json:"int32SliceMap,omitempty,omitzero"`
+	Int64SliceMap   []map[string]int64     `json:"int64SliceMap,omitempty,omitzero"`
+	UintSliceMap    []map[string]uint      `json:"uintSliceMap,omitempty,omitzero"`
+	Uint8SliceMap   []map[string]uint8     `json:"uint8SliceMap,omitempty,omitzero"`
+	Uint16SliceMap  []map[string]uint16    `json:"uint16SliceMap,omitempty,omitzero"`
+	Uint32SliceMap  []map[string]uint32    `json:"uint32SliceMap,omitempty,omitzero"`
+	Uint64SliceMap  []map[string]uint64    `json:"uint64SliceMap,omitempty,omitzero"`
+	Float32SliceMap []map[string]float32   `json:"float32SliceMap,omitempty,omitzero"`
+	Float64SliceMap []map[string]float64   `json:"float64SliceMap,omitempty,omitzero"`
+	TimeSliceMap    []map[string]time.Time `json:"timeSliceMap,omitempty,omitzero"`
+
+	// Map of string to slices
+	StringMapSlice  map[string][]string    `json:"stringMapSlice,omitempty,omitzero"`
+	BoolMapSlice    map[string][]bool      `json:"boolMapSlice,omitempty,omitzero"`
+	IntMapSlice     map[string][]int       `json:"intMapSlice,omitempty,omitzero"`
+	Int8MapSlice    map[string][]int8      `json:"int8MapSlice,omitempty,omitzero"`
+	Int16MapSlice   map[string][]int16     `json:"int16MapSlice,omitempty,omitzero"`
+	Int32MapSlice   map[string][]int32     `json:"int32MapSlice,omitempty,omitzero"`
+	Int64MapSlice   map[string][]int64     `json:"int64MapSlice,omitempty,omitzero"`
+	UintMapSlice    map[string][]uint      `json:"uintMapSlice,omitempty,omitzero"`
+	Uint8MapSlice   map[string][]uint8     `json:"uint8MapSlice,omitempty,omitzero"`
+	Uint16MapSlice  map[string][]uint16    `json:"uint16MapSlice,omitempty,omitzero"`
+	Uint32MapSlice  map[string][]uint32    `json:"uint32MapSlice,omitempty,omitzero"`
+	Uint64MapSlice  map[string][]uint64    `json:"uint64MapSlice,omitempty,omitzero"`
+	Float32MapSlice map[string][]float32   `json:"float32MapSlice,omitempty,omitzero"`
+	Float64MapSlice map[string][]float64   `json:"float64MapSlice,omitempty,omitzero"`
+	TimeMapSlice    map[string][]time.Time `json:"timeMapSlice,omitempty,omitzero"`
+
+	// Map of string to maps
+	StringMapMap  map[string]map[string]string    `json:"stringMapMap,omitempty,omitzero"`
+	BoolMapMap    map[string]map[string]bool      `json:"boolMapMap,omitempty,omitzero"`
+	IntMapMap     map[string]map[string]int       `json:"intMapMap,omitempty,omitzero"`
+	Int8MapMap    map[string]map[string]int8      `json:"int8MapMap,omitempty,omitzero"`
+	Int16MapMap   map[string]map[string]int16     `json:"int16MapMap,omitempty,omitzero"`
+	Int32MapMap   map[string]map[string]int32     `json:"int32MapMap,omitempty,omitzero"`
+	Int64MapMap   map[string]map[string]int64     `json:"int64MapMap,omitempty,omitzero"`
+	UintMapMap    map[string]map[string]uint      `json:"uintMapMap,omitempty,omitzero"`
+	Uint8MapMap   map[string]map[string]uint8     `json:"uint8MapMap,omitempty,omitzero"`
+	Uint16MapMap  map[string]map[string]uint16    `json:"uint16MapMap,omitempty,omitzero"`
+	Uint32MapMap  map[string]map[string]uint32    `json:"uint32MapMap,omitempty,omitzero"`
+	Uint64MapMap  map[string]map[string]uint64    `json:"uint64MapMap,omitempty,omitzero"`
+	Float32MapMap map[string]map[string]float32   `json:"float32MapMap,omitempty,omitzero"`
+	Float64MapMap map[string]map[string]float64   `json:"float64MapMap,omitempty,omitzero"`
+	TimeMapMap    map[string]map[string]time.Time `json:"timeMapMap,omitempty,omitzero"`
+
+	// Recursive types
+	Self           *OmitEmptyAndZeroStruct                       `json:"self,omitempty,omitzero"`
+	SelfSlice      []*OmitEmptyAndZeroStruct                     `json:"selfSlice,omitempty,omitzero"`
+	SelfMap        map[string]*OmitEmptyAndZeroStruct            `json:"selfMap,omitempty,omitzero"`
+	SelfSliceSlice [][](*OmitEmptyAndZeroStruct)                 `json:"selfSliceSlice,omitempty,omitzero"`
+	SelfSliceMap   []map[string]*OmitEmptyAndZeroStruct          `json:"selfSliceMap,omitempty,omitzero"`
+	SelfMapSlice   map[string][]*OmitEmptyAndZeroStruct          `json:"selfMapSlice,omitempty,omitzero"`
+	SelfMapMap     map[string]map[string]*OmitEmptyAndZeroStruct `json:"selfMapMap,omitempty,omitzero"`
+}
+
+func TestKYAMLEncoderFuzzRoundTrip(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		t.Run("i="+strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			// Create and fill an instance.
+			original := &AllTypesStruct{}
+			f := randfill.New().NilChance(0.5).NumElements(1, 3).MaxDepth(3)
+			f.Fill(original)
+
+			// Marshal to KYAML.
+			ky := &Encoder{}
+			yb, err := ky.Marshal(original)
+			if err != nil {
+				t.Fatalf("iteration %d: failed to render KYAML: %v", i, err)
+			}
+
+			// Parse back from KYAML with the standard parser.
+			parsed := &AllTypesStruct{}
+			if err := yaml.Unmarshal(yb, parsed); err != nil {
+				t.Fatalf("iteration %d: failed to parse KYAML: %v\nKYAML:\n%s", i, err, string(yb))
+			}
+
+			// Compare.
+			if diff := cmp.Diff(original, parsed, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("iteration %d: objects differ after round trip (-original +parsed):\n%s\nKYAML:\n%s", i, diff, string(yb))
+			}
+		})
+	}
+}
+
+func TestKYAMLOmittedField(t *testing.T) {
+	type Struct struct {
+		String string      `json:"string"`
+		Bool   bool        `json:"bool"`
+		Int    int         `json:"int"`
+		Plain  PlainStruct `json:"-"`
+	}
+
+	for i := 0; i < 1000; i++ {
+		// Create and fill an instance.
+		original := &Struct{}
+		f := randfill.New().NilChance(0.5).NumElements(1, 3).MaxDepth(3)
+		f.Fill(original)
+
+		// Marshal to KYAML.
+		ky := &Encoder{}
+		yb, err := ky.Marshal(original)
+		if err != nil {
+			t.Fatalf("iteration %d: failed to render KYAML: %v", i, err)
+		}
+
+		// Parse back from KYAML with the standard parser.
+		parsed := &Struct{}
+		if err := yaml.Unmarshal(yb, parsed); err != nil {
+			t.Fatalf("iteration %d: failed to parse KYAML: %v\nKYAML:\n%s", i, err, string(yb))
+		}
+
+		// Wipe the state that should not have been produced.
+		original.Plain = PlainStruct{}
+
+		// Compare.
+		if diff := cmp.Diff(original, parsed, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iteration %d: objects differ after round trip (-original +parsed):\n%s\nKYAML:\n%s", i, diff, string(yb))
+		}
+	}
+}
+
+type SelfMarshalStruct struct {
+	String string `json:"string,omitempty"`
+}
+
+func (s SelfMarshalStruct) MarshalJSON() ([]byte, error) {
+	return []byte(`{"key":"value"}`), nil
+}
+
+func TestKYAMLSelfMarshal(t *testing.T) {
+	original := &SelfMarshalStruct{String: "string"}
+	ky := &Encoder{}
+	yb, err := ky.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to render KYAML: %v", err)
+	}
+	expected := "{\n  key: \"value\",\n}\n"
+	if s := string(yb); s != expected {
+		t.Fatalf("wrong result:\nexpected: %q\n     got: %q", expected, s)
+	}
+}
+
+func TestKYAMLOutputSyntax(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    any
+		expected string
+	}
+
+	tests := []testCase{
+		// ints
+		{"positive int", int(123), `123`},
+		{"negative int", int(-123), `-123`},
+		{"zero int", int(0), `0`},
+		{"positive int8", int8(123), `123`},
+		{"negative int8", int8(-123), `-123`},
+		{"zero int8", int8(0), `0`},
+		{"positive int16", int16(123), `123`},
+		{"negative int16", int16(-123), `-123`},
+		{"zero int16", int16(0), `0`},
+		{"positive int32", int32(123), `123`},
+		{"negative int32", int32(-123), `-123`},
+		{"zero int32", int32(0), `0`},
+		{"positive int64", int64(123), `123`},
+		{"negative int64", int64(-123), `-123`},
+		{"zero int64", int64(0), `0`},
+		// uints
+		{"positive uint", uint(123), `123`},
+		{"zero uint", uint(0), `0`},
+		{"positive uint8", uint8(123), `123`},
+		{"zero uint8", uint8(0), `0`},
+		{"positive uint16", uint16(123), `123`},
+		{"zero uint16", uint16(0), `0`},
+		{"positive uint32", uint32(123), `123`},
+		{"zero uint32", uint32(0), `0`},
+		{"positive uint64", uint64(123), `123`},
+		{"zero uint64", uint64(0), `0`},
+		// floats
+		{"positive float32", float32(3.5), `3.5`},
+		{"negative float32", float32(-3.5), `-3.5`},
+		{"zero float32", float32(0.0), `0`},
+		{"positive float64", float64(3.5), `3.5`},
+		{"negative float64", float64(-3.5), `-3.5`},
+		{"zero float64", float64(0.0), `0`},
+		// bool
+		{"true bool", true, `true`},
+		{"false bool", false, `false`},
+		// string
+		{"empty string", "", `""`},
+		{"regular string", "abc", `"abc"`},
+		// struct
+		{"no-init struct", struct {
+			I int
+			S string
+		}{}, "{\n  I: 0,\n  S: \"\",\n}"},
+		{"init struct", struct {
+			I int
+			S string
+		}{1, "one"}, "{\n  I: 1,\n  S: \"one\",\n}"},
+		{"empty struct", struct{}{}, `{}`},
+		{"omitempty struct", struct {
+			I int    `json:",omitempty"`
+			S string `json:",omitempty"`
+			B bool   `json:",omitempty"`
+			P *int   `json:",omitempty"`
+		}{}, "{}"},
+		{"omitempty struct nil slice", struct {
+			S []int `json:",omitempty"`
+		}{}, "{}"},
+		{"omitempty struct empty slice", struct {
+			S []int `json:",omitempty"`
+		}{S: []int{}}, "{}"},
+		{"omitempty struct nil map", struct {
+			M map[int]int `json:",omitempty"`
+		}{}, "{}"},
+		{"omitempty struct empty map", struct {
+			M map[int]int `json:",omitempty"`
+		}{M: map[int]int{}}, "{}"},
+		// slice of primitive
+		{"non-empty slice", []int{1, 2, 3}, "[\n  1,\n  2,\n  3,\n]"},
+		{"empty slice", []int{}, `[]`},
+		{"nil slice", []int(nil), `null`},
+		// array of primitive
+		{"empty array", [3]int{}, "[\n  0,\n  0,\n  0,\n]"},
+		{"non-empty array", [3]int{1, 2, 3}, "[\n  1,\n  2,\n  3,\n]"},
+		{"zero-len array", [0]int{}, `[]`},
+		// map
+		{"non-empty map[string]", map[string]int{"c": 3, "a": 1, "b": 2}, "{\n  a: 1,\n  b: 2,\n  c: 3,\n}"},
+		{"non-empty map[int]", map[int]int{3: 3, 1: 1, 2: 2}, "{\n  \"1\": 1,\n  \"2\": 2,\n  \"3\": 3,\n}"},
+		{"empty map", map[string]int{}, `{}`},
+		{"nil map", map[int]int(nil), `null`},
+		{"string map with nulls", map[string]int{
+			"unambiguous": 4,
+			"null":        3,
+			"Null":        2,
+			"NULL":        1,
+			"~":           5,
+		}, "{\n  \"NULL\": 1,\n  \"Null\": 2,\n  \"null\": 3,\n  unambiguous: 4,\n  \"~\": 5,\n}"},
+		{"string map with trues", map[string]int{
+			"true": 8,
+			"True": 4,
+			"TRUE": 3,
+			"on":   7,
+			"On":   2,
+			"ON":   1,
+			"yes":  9,
+			"Yes":  6,
+			"YES":  5,
+		}, "{\n  \"ON\": 1,\n  \"On\": 2,\n  \"TRUE\": 3,\n  \"True\": 4,\n  \"YES\": 5,\n  \"Yes\": 6,\n  \"on\": 7,\n  \"true\": 8,\n  \"yes\": 9,\n}"},
+		{"string map with falses", map[string]int{
+			"false": 7,
+			"False": 2,
+			"FALSE": 1,
+			"off":   9,
+			"Off":   6,
+			"OFF":   5,
+			"no":    8,
+			"No":    4,
+			"NO":    3,
+		}, "{\n  \"FALSE\": 1,\n  \"False\": 2,\n  \"NO\": 3,\n  \"No\": 4,\n  \"OFF\": 5,\n  \"Off\": 6,\n  \"false\": 7,\n  \"no\": 8,\n  \"off\": 9,\n}"},
+		{"string map with ints", map[string]int{
+			"1":        2,
+			"-1":       1,
+			"_1":       3,
+			"__1__2__": 4,
+		}, "{\n  \"-1\": 1,\n  \"1\": 2,\n  \"_1\": 3,\n  \"__1__2__\": 4,\n}"},
+		{"string map with floats", map[string]int{
+			"3.14":  5,
+			".inf":  3,
+			"-.inf": 2,
+			"+.inf": 1,
+			".nan":  4,
+		}, "{\n  \"+.inf\": 1,\n  \"-.inf\": 2,\n  \".inf\": 3,\n  \".nan\": 4,\n  \"3.14\": 5,\n}"},
+		{"string map with unquoted keys", map[string]int{
+			"safe":              3,
+			"_":                 1,
+			"_with_underscore_": 2,
+			"with-dash":         4,
+			"with.dot":          5,
+			"with/slash":        6,
+		}, "{\n  _: 1,\n  _with_underscore_: 2,\n  safe: 3,\n  with-dash: 4,\n  with.dot: 5,\n  with/slash: 6,\n}"},
+		{"string map with quoted keys", map[string]int{
+			"not safe":        1,
+			"with\\backslash": 2,
+		}, "{\n  \"not safe\": 1,\n  \"with\\\\backslash\": 2,\n}"},
+		{"string map with dash keys", map[string]int{
+			"-":              1,
+			"-leading-dash":  2,
+			"trailing-dash-": 3,
+		}, "{\n  \"-\": 1,\n  \"-leading-dash\": 2,\n  \"trailing-dash-\": 3,\n}"},
+		{"string map with dot keys", map[string]int{
+			".":             1,
+			".leading.dot":  2,
+			"trailing.dot.": 3,
+		}, "{\n  \".\": 1,\n  \".leading.dot\": 2,\n  \"trailing.dot.\": 3,\n}"},
+		{"string map with slash keys", map[string]int{
+			"/":               1,
+			"/leading/slash":  2,
+			"trailing/slash/": 3,
+		}, "{\n  \"/\": 1,\n  \"/leading/slash\": 2,\n  \"trailing/slash/\": 3,\n}"},
+		{"string map with dates", map[string]int{
+			"2006":                            2,
+			"2006-1-2":                        3,
+			"2006-1-2T15:4:5.999999999-08:00": 4,
+			"11:00":                           1,
+		}, "{\n  \"11:00\": 1,\n  \"2006\": 2,\n  \"2006-1-2\": 3,\n  \"2006-1-2T15:4:5.999999999-08:00\": 4,\n}"},
+		{"multi-line-string-key map", map[string]int{
+			"1\n 2\n  \n3": 123,
+			"4\n 5\n  \n6": 456,
+		}, "{\n  \"1\\n 2\\n  \\n3\": 123,\n  \"4\\n 5\\n  \\n6\": 456,\n}"},
+		// pointer
+		{"non-nil pointer", new(int), `0`},
+		{"nil pointer", (*int)(nil), `null`},
+		// slice of compound
+		{"slice of struct", []struct{ I int }{
+			{1}, {2}, {3},
+		}, "[{\n  I: 1,\n}, {\n  I: 2,\n}, {\n  I: 3,\n}]"},
+		{"slice of slice", [][]int{
+			{1, 2, 3},
+			{4, 5, 6},
+			{7, 8, 9},
+		}, "[[\n  1,\n  2,\n  3,\n], [\n  4,\n  5,\n  6,\n], [\n  7,\n  8,\n  9,\n]]"},
+		{"slice of map", []map[string]int{
+			{"a": 1, "b": 2},
+			{"c": 3, "d": 4},
+			{"e": 5, "f": 6},
+		}, "[{\n  a: 1,\n  b: 2,\n}, {\n  c: 3,\n  d: 4,\n}, {\n  e: 5,\n  \"f\": 6,\n}]"},
+		// interface
+		// TODO: figure out how to make a reflect.Value where Kind() ==
+		// Interface. As far as I can tell, ValueOf() returns either the
+		// underlying type's Kind or Invalid.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ky := &Encoder{}
+			yb, err := ky.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("failed to render KYAML: %v", err)
+			}
+			// always has a newline at the end
+			if result := strings.TrimRight(string(yb), "\n"); result != tt.expected {
+				t.Errorf("Marshal(%v):\nwanted: %q\n   got: %q", tt.input, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestKYAMLFromYAML(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected string
+	}
+
+	tests := []testCase{
+		{ // Without comments
+			name:     "empty YAML",
+			input:    ``,
+			expected: ``,
+		}, {
+			name:  "int",
+			input: `42`,
+			expected: `
+				---
+				42
+				`,
+		}, {
+			name:  "bool",
+			input: `true`,
+			expected: `
+				---
+				true
+				`,
+		}, {
+			name:  "naked string",
+			input: `a string`,
+			expected: `
+				---
+				"a string"
+				`,
+		}, {
+			name:  "quoted string",
+			input: `a string`,
+			expected: `
+				---
+				"a string"
+				`,
+		}, {
+			name: "empty list",
+			input: `
+				[
+				]
+				`,
+			expected: `
+				---
+				[]
+				`,
+		}, {
+			name: "list of int",
+			input: `
+				---
+				- 1
+				- 2
+				- 3
+				`,
+			expected: `
+				---
+				[
+				  1,
+				  2,
+				  3,
+				]
+				`,
+		}, {
+			name: "list of bool",
+			input: `
+				---
+				- true
+				- false
+				- true
+				`,
+			expected: `
+				---
+				[
+				  true,
+				  false,
+				  true,
+				]
+				`,
+		}, {
+			name: "list of string",
+			input: `
+				---
+				- naked
+				- "dquoted"
+				- 'squoted'
+				`,
+			expected: `
+				---
+				[
+				  "naked",
+				  "dquoted",
+				  "squoted",
+				]
+				`,
+		}, {
+			name: "empty mapping",
+			input: `
+				{
+				}
+				`,
+			expected: `
+				---
+				{}
+				`,
+		}, {
+			name: "mapping of ints",
+			input: `
+				a: 1
+				b: 2
+				c: 3
+				`,
+			expected: `
+				---
+				{
+				  a: 1,
+				  b: 2,
+				  c: 3,
+				}
+				`,
+		}, {
+			name: "mapping of bool",
+			input: `
+				a: true
+				b: false
+				c: true
+				`,
+			expected: `
+				---
+				{
+				  a: true,
+				  b: false,
+				  c: true,
+				}
+				`,
+		}, {
+			name: "mapping of string",
+			input: `
+				a: naked
+				b: "dquoted"
+				c: 'squoted'
+				`,
+			expected: `
+				---
+				{
+				  a: "naked",
+				  b: "dquoted",
+				  c: "squoted",
+				}
+				`,
+		}, {
+			// Note: there's no escaping within single-quotes.
+			name: "mapping of strings with quotes",
+			input: `
+				a: naked "with" 'quotes' embedded
+				b: "dquoted \"with\" 'quotes' embedded"
+				c: 'squoted "with" quotes embedded'
+				`,
+			expected: `
+				---
+				{
+				  a: "naked \"with\" 'quotes' embedded",
+				  b: "dquoted \"with\" 'quotes' embedded",
+				  c: "squoted \"with\" quotes embedded",
+				}
+				`,
+		}, {
+			name: "list of list",
+			input: `
+				-
+				  - 1
+				  - 2
+				  - 3
+				-
+				  - true
+				  - false
+				  - true
+				-
+				  - naked
+				  - "dquoted"
+				  - 'squoted'
+				`,
+			expected: `
+				---
+				[[
+				  1,
+				  2,
+				  3,
+				], [
+				  true,
+				  false,
+				  true,
+				], [
+				  "naked",
+				  "dquoted",
+				  "squoted",
+				]]
+				`,
+		}, {
+			name: "list of mapping",
+			input: `
+				- a: 1
+				  b: 2
+				  c: 3
+				- a: true
+				  b: false
+				  c: true
+				- a: naked
+				  b: "dquoted"
+				  c: 'squoted'
+				`,
+			expected: `
+				---
+				[{
+				  a: 1,
+				  b: 2,
+				  c: 3,
+				}, {
+				  a: true,
+				  b: false,
+				  c: true,
+				}, {
+				  a: "naked",
+				  b: "dquoted",
+				  c: "squoted",
+				}]
+				`,
+		}, {
+			name: "mapping of list",
+			input: `
+				a:
+				- 1
+				- 2
+				- 3
+				b:
+				- true
+				- false
+				- true
+				c:
+				- naked
+				- "dquoted"
+				- 'squoted'
+				`,
+			expected: `
+				---
+				{
+				  a: [
+				    1,
+				    2,
+				    3,
+				  ],
+				  b: [
+				    true,
+				    false,
+				    true,
+				  ],
+				  c: [
+				    "naked",
+				    "dquoted",
+				    "squoted",
+				  ],
+				}
+				`,
+		}, {
+			name: "mapping with null-string keys",
+			input: `
+				null: 123
+				Null: 123
+				NULL: 123
+				~: 123
+				`,
+			expected: `
+				---
+				{
+				  "null": 123,
+				  "Null": 123,
+				  "NULL": 123,
+				  "~": 123,
+				}
+				`,
+		}, {
+			name: "mapping with true-string keys",
+			input: `
+				true: 123
+				True: 123
+				TRUE: 123
+				on: 123
+				On: 123
+				ON: 123
+				yes: 123
+				Yes: 123
+				YES: 123
+				`,
+			expected: `
+				---
+				{
+				  "true": 123,
+				  "True": 123,
+				  "TRUE": 123,
+				  "on": 123,
+				  "On": 123,
+				  "ON": 123,
+				  "yes": 123,
+				  "Yes": 123,
+				  "YES": 123,
+				}
+				`,
+		}, {
+			name: "mapping with false-string keys",
+			input: `
+				false: 123
+				False: 123
+				FALSE: 123
+				off: 123
+				Off: 123
+				OFF: 123
+				no: 123
+				No: 123
+				NO: 123
+				`,
+			expected: `
+				---
+				{
+				  "false": 123,
+				  "False": 123,
+				  "FALSE": 123,
+				  "off": 123,
+				  "Off": 123,
+				  "OFF": 123,
+				  "no": 123,
+				  "No": 123,
+				  "NO": 123,
+				}
+				`,
+		}, {
+			name: "mapping with int-string keys",
+			input: `
+				1: 123
+				-1: 123
+				+1: 123
+				_1: 123
+				-_1: 123
+				+_1: 123
+				__1__2__: 123
+				_-_1__2__: 123
+				_+_1__2__: 123
+				`,
+			expected: `
+				---
+				{
+				  "1": 123,
+				  "-1": 123,
+				  "+1": 123,
+				  "_1": 123,
+				  "-_1": 123,
+				  "+_1": 123,
+				  "__1__2__": 123,
+				  "_-_1__2__": 123,
+				  "_+_1__2__": 123,
+				}
+				`,
+		}, {
+			name: "mapping with float-string keys",
+			input: `
+				3.14: 123
+				-3.14: 123
+				+3.14: 123
+				.inf: 123
+				-.inf: 123
+				+.inf: 123
+				.nan: 123
+				`,
+			expected: `
+				---
+				{
+				  "3.14": 123,
+				  "-3.14": 123,
+				  "+3.14": 123,
+				  ".inf": 123,
+				  "-.inf": 123,
+				  "+.inf": 123,
+				  ".nan": 123,
+				}
+				`,
+		}, {
+			name: "mapping with naked-string keys",
+			input: `
+				safe: 123
+				_: 123
+				_with_underscore_: 123
+				with-dash: 123
+				with.dot: 123
+				with/slash: 123
+				`,
+			expected: `
+				---
+				{
+				  safe: 123,
+				  _: 123,
+				  _with_underscore_: 123,
+				  with-dash: 123,
+				  with.dot: 123,
+				  with/slash: 123,
+				}
+				`,
+		}, {
+			name: "mapping with unsafe-string keys",
+			input: `
+				not safe: 123
+				with\backslash: 123
+				`,
+			expected: `
+				---
+				{
+				  "not safe": 123,
+				  "with\\backslash": 123,
+				}
+				`,
+		}, {
+			name: "mapping with dash-string keys",
+			input: `
+				-: 123
+				-leading-dash: 123
+				trailing-dash-: 123
+				`,
+			expected: `
+				---
+				{
+				  "-": 123,
+				  "-leading-dash": 123,
+				  "trailing-dash-": 123,
+				}
+				`,
+		}, {
+			name: "mapping with dot-string keys",
+			input: `
+				.: 123
+				.leading.dot: 123
+				trailing.dot.: 123
+				`,
+			expected: `
+				---
+				{
+				  ".": 123,
+				  ".leading.dot": 123,
+				  "trailing.dot.": 123,
+				}
+				`,
+		}, {
+			name: "mapping with slash-string keys",
+			input: `
+				/: 123
+				/leading/slash: 123
+				trailing/slash/: 123
+				`,
+			expected: `
+				---
+				{
+				  "/": 123,
+				  "/leading/slash": 123,
+				  "trailing/slash/": 123,
+				}
+				`,
+		}, {
+			name: "mapping with date-string keys",
+			input: `
+				2006: 123
+				2006-1-2: 123
+				2006-1-2T15:4:5.999999999-08:00: 123
+				11:00: 123
+				`,
+			expected: `
+				---
+				{
+				  "2006": 123,
+				  "2006-1-2": 123,
+				  "2006-1-2T15:4:5.999999999-08:00": 123,
+				  "11:00": 123,
+				}
+				`,
+		}, {
+			name: "multi-line strings",
+			input: `
+				simple: |
+				  This is a multi-line string.
+				  It has multiple lines.
+				leading_space: |
+				  This is a multi-line string.
+				    It can
+				      retain indentation.
+				blank_lines: |
+				  This is a multi-line string.
+				
+				  It can retain blank lines.
+				`,
+			expected: `
+				---
+				{
+				  simple: "\
+				     This is a multi-line string.\n\
+				     It has multiple lines.\n\
+				    ",
+				  leading_space: "\
+				     This is a multi-line string.\n\
+				    \  It can\n\
+				    \    retain indentation.\n\
+				    ",
+				  blank_lines: "\
+				     This is a multi-line string.\n\
+				     \n\
+				     It can retain blank lines.\n\
+				    ",
+				}
+				`,
+		},
+		{ // With comments
+			name: "scalar with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				42    # This is a line comment
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				42 # This is a line comment
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "multi-line string with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				foo: |    # This is a line comment
+				  this is a
+				  multi-line
+				  comment
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				{
+				  # This is a head comment.
+				  # It can be multi-line.
+				  foo: "\
+				     this is a\n\
+				     multi-line\n\
+				     comment\n\
+				    ", # This is a line comment
+				  # This is a foot comment.
+				  # It can also be multi-line.
+				}
+				`,
+		}, {
+			name: "block sequence with comments",
+			input: `
+				# This seems like a head comment.
+				# But it will be attributed to the first item.
+				- 1    # line1
+				- 2    # line2
+				- 3    # line3
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				[
+				  # This seems like a head comment.
+				  # But it will be attributed to the first item.
+				  1, # line1
+				  2, # line2
+				  3, # line3
+				  # This is a foot comment.
+				  # It can also be multi-line.
+				]
+				`,
+		}, {
+			name: "short flow sequence with line-comment",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				[ 1, 2, 3 ]    # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				[
+				  1,
+				  2,
+				  3,
+				] # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "flow sequence with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				[ # This will be lost.
+				  1,    # line1
+				  2,    # line2
+				  3,    # line3
+				] # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				[
+				  1, # line1
+				  2, # line2
+				  3, # line3
+				] # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {}, {
+			name: "block mapping with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				foo: 1    # line1
+				bar: 2    # line2
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				{
+				  # This is a head comment.
+				  # It can be multi-line.
+				  foo: 1, # line1
+				  bar: 2, # line2
+				  # This is a foot comment.
+				  # It can also be multi-line.
+				}
+				`,
+		}, {
+			name: "short flow mapping with line-comment",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				{ foo: 1, bar: 2 }    # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				{
+				  foo: 1,
+				  bar: 2,
+				} # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "flow mapping with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				{    # This will be lost.
+				  foo: 1,    # line1
+				  bar: 2,    # line2
+				}    # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				{
+				  foo: 1, # line1
+				  bar: 2, # line2
+				} # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "list of list with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				[    # This will be lost.
+				  [1],
+				  [2],
+				  # head3
+				  [3],
+				  [4],
+				  # foot4
+				  [5],
+				  # foot5
+				  # head6
+				  [6],
+				  [7],    # line7
+				  [8],
+				  [9],    # line9
+				]    # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				[
+				  [
+				    1,
+				  ],
+				  [
+				    2,
+				  ],
+				  # head3
+				  [
+				    3,
+				  ],
+				  [
+				    4,
+				  ],
+				  # foot4
+				  [
+				    5,
+				  ],
+				  # foot5
+				  # head6
+				  [
+				    6,
+				  ],
+				  [
+				    7,
+				  ], # line7
+				  [
+				    8,
+				  ],
+				  [
+				    9,
+				  ], # line9
+				] # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "list of map with comments",
+			input: `
+				# This is a head comment.
+				# It can be multi-line.
+				[    # This will be lost.
+				  {fld: 1},
+				  {fld: 2},
+				  # head3
+				  {fld: 3},
+				  {fld: 4},
+				  # foot4
+				  {fld: 5},
+				  # foot5
+				  # head6
+				  {fld: 6},
+				  {fld: 7},    # line7
+				  {fld: 8},
+				  {fld: 9},    # line9
+				]    # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This is a head comment.
+				# It can be multi-line.
+				[
+				  {
+				    fld: 1,
+				  },
+				  {
+				    fld: 2,
+				  },
+				  # head3
+				  {
+				    fld: 3,
+				  },
+				  {
+				    fld: 4,
+				  },
+				  # foot4
+				  {
+				    fld: 5,
+				  },
+				  # foot5
+				  # head6
+				  {
+				    fld: 6,
+				  },
+				  {
+				    fld: 7,
+				  }, # line7
+				  {
+				    fld: 8,
+				  },
+				  {
+				    fld: 9,
+				  }, # line9
+				] # This is a line comment.
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		}, {
+			name: "list of mixed types",
+			input: `
+				[
+				  "a string",
+				  12345,
+				  true,
+				  {fld: 1},
+				  [a, b, c],
+				]
+				`,
+			expected: `
+				---
+				[
+				  "a string",
+				  12345,
+				  true,
+				  {
+				    fld: 1,
+				  },
+				  [
+				    "a",
+				    "b",
+				    "c",
+				  ],
+				]
+				`,
+		}, {
+			name: "doc comments",
+			input: `
+				# This seems like a doc comment.
+				# But it will be attributed to the content.
+				---
+				# This is a head comment.
+				42    # This is a line comment
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+			expected: `
+				---
+				# This seems like a doc comment.
+				# But it will be attributed to the content.
+				# This is a head comment.
+				42 # This is a line comment
+				# This is a foot comment.
+				# It can also be multi-line.
+				`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ky := &Encoder{}
+
+			// Trimming is just for test output since all test cases have
+			// leading and trailing newlines.
+			input := strings.TrimPrefix(tt.input, "\n")
+			input = strings.TrimSuffix(input, "\n")
+			input = dedent(input)
+
+			expected := strings.TrimPrefix(tt.expected, "\n")
+			expected = strings.TrimSuffix(expected, "\n")
+			expected = dedent(expected)
+
+			buf := &bytes.Buffer{}
+			if err := ky.FromYAML(strings.NewReader(input), buf); err != nil {
+				t.Fatalf("FromYAML(%q) returned error: %v", input, err)
+			}
+			if want, got := expected, buf.String(); got != want {
+				t.Errorf("FromYAML:\nexpected:\n```\n%s\n```\ngot:\n```\n%s\n```", expected, got)
+			}
+		})
+	}
+}
+
+func TestIsTypeAmbiguous(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    string
+		expected bool
+	}
+
+	tests := []testCase{
+		// Regular strings that should not need quotes
+		{"regular string", "regular", false},
+		{"alphanumeric", "abc123", false},
+		{"underscore", "hello_world", false},
+		{"hyphen", "hello-world", false},
+
+		// Boolean-like strings
+		{"yes", "yes", true},
+		{"YES", "YES", true},
+		{"y", "y", true},
+		{"Y", "Y", true},
+		{"no", "no", true},
+		{"NO", "NO", true},
+		{"n", "n", true},
+		{"N", "N", true},
+		{"on", "on", true},
+		{"ON", "ON", true},
+		{"off", "off", true},
+		{"OFF", "OFF", true},
+
+		// Numbers should stay strings
+		{"decimal", "1234", true},
+		{"underscores", "_1_2_3_4_", true},
+		{"leading zero", "0123", true},
+		{"plus sign", "+123", true},
+		{"negative sign", "-123", true},
+		{"large decimal", "123456789012345678901234567890", true},
+		{"octal 0", "0777", true},
+		{"octal 0o", "0o777", true},
+		{"hex lowercase", "0xff", true},
+		{"hex uppercase", "0xFF", true},
+
+		// Infinity and NaN
+		{"infinity", ".inf", true},
+		{"negative infinity", "-.inf", true},
+		{"positive infinity", "+.inf", true},
+		{"not a number", ".nan", true},
+		{"uppercase infinity", ".INF", true},
+		{"uppercase nan", ".NAN", true},
+
+		// Scientific notation
+		{"scientific", "1e10", true},
+		{"scientific uppercase", "1E10", true},
+
+		// Timestamp-like strings
+		{"year", "2006", true},
+		{"date", "2006-1-2", true},
+		{"RCF3339Nano with short date", "2006-1-2T15:4:5.999999999-08:00", true},
+		{"RCF3339Nano with lowercase t", "2006-1-2t15:4:5.999999999-08:00", true},
+		{"space separated", "2006-1-2 14:4:5.999999999", true},
+
+		// Sexagesimal strings
+		{"small sexagesimal int", "1:00", true},
+		{"large sexagesimal int 59", "12345:59", true},
+		{"invalid sexagesimal int", "1:60", false},
+		{"multi-part sexagesimal", "1:2:3:4:5:00:00:01", true},
+		{"small sexagesimal float 0", "1:00.0", true},
+		{"small sexagesimal float 59", "12345:59.59", true},
+		{"small non-sexagesimal int", "12345:60.00", false},
+		{"multi-part sexagesimal", "1:2:3:4:5:00:00:01.02", true},
+
+		// Null-like strings
+		{"null lowercase", "null", true},
+		{"null mixed", "Null", true},
+		{"null uppercase", "NULL", true},
+		{"tilde", "~", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTypeAmbiguous(tt.input)
+			if result != tt.expected {
+				t.Errorf("isTypeAmbiguous(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/yamlfmt/yamlfmt.go
+++ b/yamlfmt/yamlfmt.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+	"sigs.k8s.io/yaml/kyaml"
+)
+
+const (
+	fmtYAML  = "yaml"
+	fmtKYAML = "kyaml"
+)
+
+func main() {
+	fs := flag.NewFlagSet("yamlfmt", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "usage: %s [<yaml-files>...]\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(fs.Output(), "If no files are specified, stdin will be used.\n")
+		fs.PrintDefaults()
+	}
+
+	diff := fs.Bool("d", false, "diff input files with their formatted versions")
+	help := fs.Bool("h", false, "print help and exit")
+	format := fs.String("o", "yaml", "output format: may be 'yaml' or 'kyaml'")
+	write := fs.Bool("w", false, "write result to input files instead of stdout")
+	fs.Parse(os.Args[1:])
+
+	if *help {
+		fs.SetOutput(os.Stdout)
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	switch *format {
+	case "yaml", "kyaml":
+		// OK
+	default:
+		fmt.Fprintf(os.Stderr, "unknown output format %q, must be one of 'yaml' or 'kyaml'\n", *format)
+		os.Exit(1)
+	}
+	if *diff && *write {
+		fmt.Fprintln(os.Stderr, "cannot use -d and -w together")
+	}
+
+	files := fs.Args()
+
+	if len(files) == 0 {
+		if err := renderYAML("<stdin>", os.Stdin, *format, *diff, os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	for i, path := range files {
+		// use a func to catch defer'ed Close
+		func() {
+			// Read the YAML file
+			sourceYaml, err := os.ReadFile(path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s: %v\n", path, err)
+				return
+			}
+			in := bytes.NewReader(sourceYaml)
+
+			out := os.Stdout
+			finalize := func() {}
+			if *write {
+				// Write to a temp file and rename when done.
+				tmp, err := os.CreateTemp(filepath.Dir(path), ".yamlfmt.tmp.")
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+					os.Exit(1)
+				}
+				defer tmp.Close()
+				finalize = func() {
+					if err := os.Rename(tmp.Name(), path); err != nil {
+						fmt.Fprintf(os.Stderr, "%v\n", err)
+						os.Exit(1)
+					}
+				}
+				out = tmp
+			}
+			if len(files) > 1 && !*write && !*diff {
+				if i > 0 {
+					fmt.Fprintln(out, "")
+				}
+				fmt.Fprintln(out, "# "+path)
+			}
+			if err := renderYAML(path, in, *format, *diff, out); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			finalize()
+		}()
+	}
+}
+
+func renderYAML(path string, in io.Reader, format string, printDiff bool, out io.Writer) error {
+	if format == fmtKYAML {
+		ky := &kyaml.Encoder{}
+
+		if printDiff {
+			ibuf, err := io.ReadAll(in)
+			if err != nil {
+				return err
+			}
+			obuf := bytes.Buffer{}
+			if err := ky.FromYAML(bytes.NewReader(ibuf), &obuf); err != nil {
+				return err
+			}
+			d := trivialDiff(path, string(ibuf), obuf.String())
+			fmt.Fprint(out, d)
+			return nil
+		}
+
+		return ky.FromYAML(in, out)
+	}
+
+	// else format == fmtYAML
+
+	var decoder *yaml.Decoder
+	var encoder *yaml.Encoder
+	var finish func()
+
+	if printDiff {
+		ibuf, err := io.ReadAll(in)
+		if err != nil {
+			return err
+		}
+		obuf := bytes.Buffer{}
+		decoder = yaml.NewDecoder(bytes.NewReader(ibuf))
+		encoder = yaml.NewEncoder(&obuf)
+		finish = func() {
+			d := trivialDiff(path, string(ibuf), obuf.String())
+			fmt.Fprint(out, d)
+		}
+	} else {
+		decoder = yaml.NewDecoder(in)
+		encoder = yaml.NewEncoder(out)
+	}
+	encoder.SetIndent(2)
+
+	for {
+		var node yaml.Node // to retain comments
+		if err := decoder.Decode(&node); err != nil {
+			if err == io.EOF {
+				break // End of input
+			}
+			return fmt.Errorf("failed to decode input: %w", err)
+		}
+		setBlockStyle(&node) // In case we read KYAML as input.
+		if err := encoder.Encode(&node); err != nil {
+			return fmt.Errorf("failed to encode node: %w", err)
+		}
+	}
+	if finish != nil {
+		finish()
+	}
+	return nil
+}
+
+func trivialDiff(path, a, b string) string {
+	if a == b {
+		return ""
+	}
+
+	x := strings.Split(strings.TrimSuffix(a, "\n"), "\n")
+	y := strings.Split(strings.TrimSuffix(b, "\n"), "\n")
+	buf := bytes.Buffer{}
+	buf.WriteString(fmt.Sprintf("--- %s\n+++ %s\n", path, path))
+	buf.WriteString(fmt.Sprintf("@@ -%d,%d +%d,%d\n", 1, len(x), 1, len(y)))
+	for {
+		n := 0
+		for ; n < len(x) && n < len(y) && x[n] == y[n]; n++ {
+			buf.WriteString(" " + x[n] + "\n")
+		}
+		x = x[n:]
+		y = y[n:]
+
+		nextX, nextY := nextCommon(x, y)
+		for i := range nextX {
+			buf.WriteString("-" + x[i] + "\n")
+		}
+		x = x[nextX:]
+		for j := range nextY {
+			buf.WriteString("+" + y[j] + "\n")
+		}
+		y = y[nextY:]
+
+		if len(x) == 0 && len(y) == 0 {
+			break
+		}
+	}
+	return buf.String()
+}
+
+func nextCommon(x, y []string) (int, int) {
+	for i := range len(x) {
+		for j := range len(y) {
+			if x[i] == y[j] {
+				return i, j
+			}
+		}
+	}
+	return len(x), len(y)
+}
+
+func setBlockStyle(node *yaml.Node) {
+	node.Style = node.Style & (^yaml.FlowStyle)
+	for _, child := range node.Content {
+		setBlockStyle(child)
+	}
+}


### PR DESCRIPTION
KEP https://github.com/kubernetes/enhancements/issues/5295

KYAML is a strict subset of YAML, which is sort of halfway between YAML and JSON.  It has the following properties:
* Does not depend on whitespace (easier to text-patch and template).
* Always quotes value strings (no ambiguity aroud things like "no").
* Allows quoted keys, but does not require them, and only quotes them if they are not obviously safe (e.g. "no" would always be quoted).
* Always uses {} for structs and maps (no more obscure errors about mapping values).
* Always uses [] for lists (no more trying to figure out if a dash changes the meaning).
* When printing, it includes a header which makes it clear this is YAML and not ill-formed JSON.
* Allows trailing commas
* Allows comments,
* Tries to economize on vertical space by "cuddling" some kinds of brackets together.
* Retains comments.

Output from `kubectl get -o kyaml` can be fed back into `kubectl`.

Examples:

A struct:

```yaml
metadata: {
  creationTimestamp: "2024-12-11T00:10:11Z",
  labels: {
    app: "hostnames",
  },
  name: "hostnames",
  namespace: "default",
  resourceVersion: "15231643",
  uid: "f64dbcba-9c58-40b0-bbe7-70495efb5202",
}
```

A list of primitves:

```yaml
ipFamilies: [
  "IPv4",
  "IPv6",
]
```

A list of structs:

```yaml
ports: [{
  port: 80,
  protocol: "TCP",
  targetPort: 80,
}, {
  port: 443,
  protocol: "TCP",
  targetPort: 443,
}]
```

A multi-document stream:

```yaml
---
{
  foo: "bar",
}
---
{
  qux: "zrb",
}
```