### PR TITLE
Forgot to add redirects for v3 constants

### DIFF
--- a/goyaml.v3/yaml_aliases.go
+++ b/goyaml.v3/yaml_aliases.go
@@ -46,18 +46,68 @@ type (
 	// TypeError is returned by Unmarshal when one or more fields in the YAML document cannot be properly decoded.
 	// Deprecated: Use go.yaml.in/yaml/v3.TypeError directly.
 	TypeError = gopkg_yaml.TypeError
-	
+
 	// Node represents a YAML node in the document.
 	// Deprecated: Use go.yaml.in/yaml/v3.Node directly.
 	Node = gopkg_yaml.Node
-	
+
 	// Kind represents the kind of a YAML node.
 	// Deprecated: Use go.yaml.in/yaml/v3.Kind directly.
 	Kind = gopkg_yaml.Kind
-	
+
 	// Style represents the style of a YAML node.
 	// Deprecated: Use go.yaml.in/yaml/v3.Style directly.
 	Style = gopkg_yaml.Style
+)
+
+// Constants for Kind type from go.yaml.in/yaml/v3
+const (
+	// DocumentNode represents a YAML document node.
+	// Deprecated: Use go.yaml.in/yaml/v3.DocumentNode directly.
+	DocumentNode = gopkg_yaml.DocumentNode
+
+	// SequenceNode represents a YAML sequence node.
+	// Deprecated: Use go.yaml.in/yaml/v3.SequenceNode directly.
+	SequenceNode = gopkg_yaml.SequenceNode
+
+	// MappingNode represents a YAML mapping node.
+	// Deprecated: Use go.yaml.in/yaml/v3.MappingNode directly.
+	MappingNode = gopkg_yaml.MappingNode
+
+	// ScalarNode represents a YAML scalar node.
+	// Deprecated: Use go.yaml.in/yaml/v3.ScalarNode directly.
+	ScalarNode = gopkg_yaml.ScalarNode
+
+	// AliasNode represents a YAML alias node.
+	// Deprecated: Use go.yaml.in/yaml/v3.AliasNode directly.
+	AliasNode = gopkg_yaml.AliasNode
+)
+
+// Constants for Style type from go.yaml.in/yaml/v3
+const (
+	// TaggedStyle represents a tagged YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.TaggedStyle directly.
+	TaggedStyle = gopkg_yaml.TaggedStyle
+
+	// DoubleQuotedStyle represents a double-quoted YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.DoubleQuotedStyle directly.
+	DoubleQuotedStyle = gopkg_yaml.DoubleQuotedStyle
+
+	// SingleQuotedStyle represents a single-quoted YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.SingleQuotedStyle directly.
+	SingleQuotedStyle = gopkg_yaml.SingleQuotedStyle
+
+	// LiteralStyle represents a literal YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.LiteralStyle directly.
+	LiteralStyle = gopkg_yaml.LiteralStyle
+
+	// FoldedStyle represents a folded YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.FoldedStyle directly.
+	FoldedStyle = gopkg_yaml.FoldedStyle
+
+	// FlowStyle represents a flow YAML style.
+	// Deprecated: Use go.yaml.in/yaml/v3.FlowStyle directly.
+	FlowStyle = gopkg_yaml.FlowStyle
 )
 
 // Function aliases for public functions from go.yaml.in/yaml/v3


### PR DESCRIPTION
Found when i throw sigs.k8s.io/yaml HEAD into the chopper with k/k, typecheck showed that i forgot to add redirects for public constants when i filed https://github.com/kubernetes-sigs/yaml/pull/133

https://github.com/kubernetes/kubernetes/pull/132357
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/132357/pull-kubernetes-typecheck/1937844052523225088

```
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:84:32: undefined: yaml.AliasNode
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:85:35: undefined: yaml.DocumentNode
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:86:34: undefined: yaml.MappingNode
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:87:33: undefined: yaml.ScalarNode
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:88:35: undefined: yaml.SequenceNode
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:100:41: undefined: yaml.DoubleQuotedStyle
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:101:33: undefined: yaml.FlowStyle
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:102:35: undefined: yaml.FoldedStyle
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:103:36: undefined: yaml.LiteralStyle
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:104:41: undefined: yaml.SingleQuotedStyle
ERROR(linux/arm): /home/prow/go/src/k8s.io/kubernetes/vendor/sigs.k8s.io/kustomize/kyaml/yaml/alias.go:105:35: undefined: yaml.TaggedStyle
```

cross checked that v2 does not have similar constants!